### PR TITLE
Finch: bump Unlock Plus to 3.73.181 (arm64)

### DIFF
--- a/patches/src/main/kotlin/hooman/morphe/patches/finch/plus/UnlockPlusPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/finch/plus/UnlockPlusPatch.kt
@@ -28,7 +28,7 @@ import app.morphe.patcher.patch.rawResourcePatch
 // (the true constant, the function's own frame teardown, and the function's own "yearly" load from
 // the object pool). No new bl and no new pool materialization, which is the relocation class most
 // likely to crash at runtime. The bytes are machine code, so offsets and the object-pool slot shift
-// between releases; this is pinned to the 3.73.179 arm64 build and must be re-derived per version with
+// between releases; this is pinned to the 3.73.181 arm64 build and must be re-derived per version with
 // Blutter.
 @Suppress("unused")
 val unlockPlusPatch = rawResourcePatch(
@@ -44,7 +44,7 @@ val unlockPlusPatch = rawResourcePatch(
             name = "Finch",
             packageName = "com.finch.finch",
             appIconColor = 0xBFC2D0,
-            targets = listOf(AppTarget("3.73.179")),
+            targets = listOf(AppTarget("3.73.181")),
         ),
     )
 
@@ -53,7 +53,7 @@ val unlockPlusPatch = rawResourcePatch(
         val lib = get(libPath)
         if (!lib.exists()) {
             throw PatchException(
-                "$libPath not found in the APK. This targets the arm64 Finch 3.73.179 build; apk-pure " +
+                "$libPath not found in the APK. This targets the arm64 Finch 3.73.181 build; apk-pure " +
                     "often serves a v7a-only bundle, so apply this to a merged arm64 universal built " +
                     "from a Play Store .apks export or the xapk split bundle (it carries " +
                     "split_config.arm64_v8a.apk). Merge it to a universal with APKEditor m first.",
@@ -62,10 +62,10 @@ val unlockPlusPatch = rawResourcePatch(
 
         val bytes = lib.readBytes()
 
-        // isUserSubscribed() @ 0x13e099c. The signature spans the entry through the two object-pool
+        // isUserSubscribed() @ 0x12f77b0. The signature spans the entry through the two object-pool
         // loads that are specific to this function (the <bool?> type args at pp+0x8680 and the
         // FinchSettingType override setting at pp+0xb198), so it can't collide with the other
-        // finchSettingsManager getters that share the prologue. Unique in the 3.73.179 libapp.so:
+        // finchSettingsManager getters that share the prologue. Unique in the 3.73.181 libapp.so:
         //   stp  x29, x30, [x15, #-0x10]!   ; EnterFrame                     (signature[0..4])
         //   mov  x29, x15
         //   sub  x15, x15, #0x20            ; AllocStack                     (overwrite starts here)
@@ -76,15 +76,15 @@ val unlockPlusPatch = rawResourcePatch(
             0xef, 0x81, 0x00, 0xd1, // sub  x15, x15, #0x20
             0x50, 0x1f, 0x40, 0xf9, // ldr  x16, [x26, #0x38]   THR::stack_limit
             0xff, 0x01, 0x10, 0xeb, // cmp  x15, x16
-            0x49, 0x0a, 0x00, 0x54, // b.ls #0x13e0af8
+            0x49, 0x0a, 0x00, 0x54, // b.ls #0x12f790c
             0x40, 0x37, 0x40, 0xf9, // ldr  x0, [x26, #0x68]    field_table_values
             0x00, 0x3c, 0x52, 0xf9, // ldr  x0, [x0, #0x2478]
             0x70, 0x23, 0x40, 0xf9, // ldr  x16, [x27, #0x40]   Sentinel
             0x1f, 0x00, 0x10, 0x6b, // cmp  w0, w16
-            0x81, 0x00, 0x00, 0x54, // b.ne #0x13e09d4
+            0x81, 0x00, 0x00, 0x54, // b.ne #0x12f77e8
             0x62, 0x23, 0x40, 0x91, // add  x2, x27, #8, lsl #12
             0x42, 0xe4, 0x41, 0xf9, // ldr  x2, [x2, #0x3c8]    Field finchSettingsManager
-            0xf0, 0x0f, 0x49, 0x94, // bl   InitLateFinalStaticFieldStub
+            0x33, 0xb7, 0x4c, 0x94, // bl   InitLateFinalStaticFieldStub
             0x70, 0x23, 0x40, 0x91, // add  x16, x27, #8, lsl #12
             0x10, 0x42, 0x43, 0xf9, // ldr  x16, [x16, #0x680]  <bool?> type args (pp+0x8680)
         ).map { it.toByte() }.toByteArray()
@@ -104,8 +104,8 @@ val unlockPlusPatch = rawResourcePatch(
             0xc0, 0x03, 0x5f, 0xd6,
         ).map { it.toByte() }.toByteArray()
 
-        // getUserSubscriptionState() @ 0x13e08f0. Signature spans the entry through the call to
-        // getAccountId and the load of the per-account settings key "8LLJTDVPH1" (pp+0x60540), which is
+        // getUserSubscriptionState() @ 0x12f7704. Signature spans the entry through the call to
+        // getAccountId and the load of the per-account settings key "8LLJTDVPH1" (pp+0x34378), which is
         // unique to this getter.
         //   stp  x29, x30, [x15, #-0x10]!   ; EnterFrame                     (signature[0..4])
         //   mov  x29, x15
@@ -117,33 +117,33 @@ val unlockPlusPatch = rawResourcePatch(
             0xef, 0x61, 0x00, 0xd1, // sub  x15, x15, #0x18
             0x50, 0x1f, 0x40, 0xf9, // ldr  x16, [x26, #0x38]   THR::stack_limit
             0xff, 0x01, 0x10, 0xeb, // cmp  x15, x16
-            0x89, 0x04, 0x00, 0x54, // b.ls #0x13e0994
-            0x46, 0x9c, 0x05, 0x94, // bl   getAccountId
+            0x89, 0x04, 0x00, 0x54, // b.ls #0x12f77a8
+            0xa1, 0xac, 0x05, 0x94, // bl   getAccountId
             0x01, 0xf0, 0x5f, 0xf8, // ldur x1, [x0, #-1]
             0x21, 0x7c, 0x4c, 0xd3, // ubfx x1, x1, #0xc, #0x14
-            0x70, 0x83, 0x41, 0x91, // add  x16, x27, #0x60, lsl #12
-            0x10, 0xa2, 0x42, 0xf9, // ldr  x16, [x16, #0x540]  "8LLJTDVPH1" (pp+0x60540)
+            0x70, 0xd3, 0x40, 0x91, // add  x16, x27, #0x34, lsl #12
+            0x10, 0xbe, 0x41, 0xf9, // ldr  x16, [x16, #0x378]  "8LLJTDVPH1" (pp+0x34378)
         ).map { it.toByte() }.toByteArray()
 
         // Overwrite the AllocStack at signature offset 8 with a constant-"yearly" return. The "yearly"
-        // string lives in the object pool at pp+0x60548; this is the exact load the function already
+        // string lives in the object pool at pp+0x34380; this is the exact load the function already
         // uses on its own "yearly" path, so there is no relocation.
-        //   add  x0, x27, #0x60, lsl #12   ; PP base (x27 is the object pool)
-        //   ldr  x0, [x0, #0x548]          ; x0 = "yearly"
+        //   add  x0, x27, #0x34, lsl #12   ; PP base (x27 is the object pool)
+        //   ldr  x0, [x0, #0x380]          ; x0 = "yearly"
         //   mov  x15, x29                  ; LeaveFrame
         //   ldp  x29, x30, [x15], #0x10
         //   ret
         val getStateOverwriteAt = 8
         val getStateOverwrite = intArrayOf(
-            0x60, 0x83, 0x41, 0x91,
-            0x00, 0xa4, 0x42, 0xf9,
+            0x60, 0xd3, 0x40, 0x91,
+            0x00, 0xc0, 0x41, 0xf9,
             0xef, 0x03, 0x1d, 0xaa,
             0xfd, 0x79, 0xc1, 0xa8,
             0xc0, 0x03, 0x5f, 0xd6,
         ).map { it.toByte() }.toByteArray()
 
         // Both are mandatory: same build, same version pin, so a missing or ambiguous signature means
-        // the input isn't the expected 3.73.179 arm64 libapp.so. Fail loud rather than apply a partial
+        // the input isn't the expected 3.73.181 arm64 libapp.so. Fail loud rather than apply a partial
         // unlock.
         listOf(
             Triple("isUserSubscribed", isUserSubscribedSig, isUserSubscribedOverwrite to isUserSubscribedOverwriteAt),
@@ -153,7 +153,7 @@ val unlockPlusPatch = rawResourcePatch(
             val match = bytes.findUnique(signature)
                 ?: throw PatchException(
                     "Finch Plus signature ($label) not found in $libPath. This patch targets Finch " +
-                        "3.73.179 (arm64); a different build shifts these offsets and the object-pool " +
+                        "3.73.181 (arm64); a different build shifts these offsets and the object-pool " +
                         "slots, so the signature must be re-derived with Blutter.",
                 )
             overwrite.forEachIndexed { i, b -> bytes[match + overwriteAt + i] = b }


### PR DESCRIPTION
Re-pins **Unlock Plus** from 3.73.179 to **3.73.181**. The two functions moved and the object pool shifted, so the signatures and the `"yearly"` return are re-derived against the 3.73.181 arm64 `libapp.so` with Blutter.

## Changes
| | 3.73.179 | 3.73.181 |
|---|---|---|
| `isUserSubscribed()` | `0x13e099c` | `0x12f77b0` |
| `getUserSubscriptionState()` | `0x13e08f0` | `0x12f7704` |
| `"yearly"` pool slot | `pp+0x60548` | `pp+0x34380` |
| account key `"8LLJTDVPH1"` | `pp+0x60540` | `pp+0x34378` |

For `isUserSubscribed` the **only** signature byte that changed is the `InitLateFinalStaticFieldStub` `bl` offset — the `<bool?>` type-args (`pp+0x8680`) and `finchSettingsManager` field (`pp+0x83c8`) slots are unchanged, and the constant-true overwrite is byte-identical. For `getUserSubscriptionState` the `getAccountId` `bl` offset and the two pool slots moved; the overwrite now loads `"yearly"` from `pp+0x34380`.

## Verification
- Both signatures verified **unique** at their expected addresses in the 3.73.181 `libapp.so`.
- Unlock verified **on-device** against the 3.73.181 build.

## Note
This **re-pins** rather than adding a second `AppTarget`. The offsets and pool slots differ between the two builds, so a single byte signature can't cover both — supporting 3.73.179 and 3.73.181 simultaneously would need per-version signature sets. Happy to restructure it that way instead if you'd prefer to keep 3.73.179 support.

Pairs with the companion PR adding the Unlock Guardian patch.