### PR TITLE
fix: Poweramp settings export and Symfonium beta cutoff

### DIFF
--- a/patches/src/main/kotlin/hooman/morphe/patches/poweramp/premium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/poweramp/premium/UnlockPremiumPatch.kt
@@ -185,6 +185,58 @@ private val arm64NativeProbePatches = listOf(
         offset = 8,
         replacement = movW(register = 8, value = 0),
     ),
+    // Settings export/import buildstamp deref (issue #94). On a re-signed build the native
+    // buildstamp string derivation returns null (the JNI signature read can't match the original
+    // cert in the re-signed apk), leaving the global pointer at 0x888060 null while its length at
+    // 0x372a30 stays nonzero. This thunk feeds both into a string-hash keyed map insert, so the
+    // hash loop reads the null pointer and SIGSEGVs. It runs on the export/import path (crash lands
+    // right after ExporterImpl serializes the presets), which is why export writes a 0-byte file,
+    // import fails with "Error loading: settings-export", and the settings screen "closes" (the
+    // process dies). Force the length load to 0: the hash loop guard then skips the read entirely,
+    // so the null pointer is never dereferenced and the insert proceeds with an empty key.
+    NativeProbePatch(
+        label = "buildstamp-hash-export",
+        signature = ints(
+            0xE8, 0x30, 0x00, 0xF0, 0x01, 0x31, 0x40, 0xF9,
+            0x48, 0x08, 0x00, 0xB0, 0x02, 0x31, 0x4A, 0xB9,
+            0x85, 0x80, 0xFE, 0x97,
+        ),
+        offset = 12,
+        replacement = movW(register = 2, value = 0),
+    ),
+    // Remaining *0x888060 byte-table loads not covered by the original probes (issue #114). Same
+    // null pointer as above; these sites still do ldrb off it. 0x328 is a guard (cbnz into a fail
+    // path) hit from the audio/settings config path; 0x263 is a size multiplier. Force guard=0 and
+    // size=1 so the null is never dereferenced.
+    NativeProbePatch(
+        label = "guard-328-a",
+        signature = ints(
+            0x89, 0x33, 0x00, 0xF0, 0x29, 0x31, 0x40, 0xF9,
+            0x29, 0xA1, 0x4C, 0x39, 0x49, 0xF3, 0x00, 0x35,
+        ),
+        offset = 8,
+        replacement = movW(register = 9, value = 0),
+    ),
+    NativeProbePatch(
+        label = "guard-328-b",
+        signature = ints(
+            0x29, 0x31, 0x40, 0xF9, 0x08, 0x05, 0x00, 0x32,
+            0x29, 0xA1, 0x4C, 0x39, 0x88, 0x92, 0x0A, 0xB9,
+        ),
+        offset = 8,
+        replacement = movW(register = 9, value = 0),
+    ),
+    NativeProbePatch(
+        label = "size-263",
+        signature = ints(
+            0xC9, 0x30, 0x00, 0x90, 0x88, 0x02, 0x40, 0xF9,
+            0xE0, 0x03, 0x14, 0xAA, 0x29, 0x31, 0x40, 0xF9,
+            0x08, 0xAD, 0x42, 0xF9, 0x29, 0x8D, 0x49, 0x39,
+            0x21, 0x7D, 0x13, 0x9B,
+        ),
+        offset = 20,
+        replacement = movW(register = 9, value = 1),
+    ),
 )
 
 @Suppress("unused")

--- a/patches/src/main/kotlin/hooman/morphe/patches/poweramp/premium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/poweramp/premium/UnlockPremiumPatch.kt
@@ -10,6 +10,7 @@ import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.rawResourcePatch
 import app.morphe.patcher.util.smali.ExternalLabel
+import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
@@ -185,15 +186,34 @@ private val arm64NativeProbePatches = listOf(
         offset = 8,
         replacement = movW(register = 8, value = 0),
     ),
-    // Settings export/import buildstamp deref (issue #94). On a re-signed build the native
-    // buildstamp string derivation returns null (the JNI signature read can't match the original
-    // cert in the re-signed apk), leaving the global pointer at 0x888060 null while its length at
-    // 0x372a30 stays nonzero. This thunk feeds both into a string-hash keyed map insert, so the
-    // hash loop reads the null pointer and SIGSEGVs. It runs on the export/import path (crash lands
-    // right after ExporterImpl serializes the presets), which is why export writes a 0-byte file,
-    // import fails with "Error loading: settings-export", and the settings screen "closes" (the
-    // process dies). Force the length load to 0: the hash loop guard then skips the read entirely,
-    // so the null pointer is never dereferenced and the insert proceeds with an empty key.
+    // Settings export/import (issue #94). Re-sign: JNI cert read fails, buildstamp writer at
+    // 0x26d344 stores null to *0x888060 then cbz-skips the rest of init (and the follow-up bl
+    // 0x35bce0 that arms export crypto). Downstream either SIGSEGVs on hash-insert or writes a
+    // 0-byte export. Force the writer to plant in-binary C string "unknown" @ VA 0x4a91f with
+    // length 7 into both globals AND x27 (the bl's length arg), then fall through into the
+    // original mov x2,x27 / bl 0x35bce0. 32 bytes @ 0x26d344.
+    NativeProbePatch(
+        label = "buildstamp-writer-force",
+        signature = ints(
+            0xE0, 0x03, 0x1B, 0xAA, 0x8E, 0xB9, 0x03, 0x94,
+            0xC8, 0x30, 0x00, 0xF0, 0x00, 0x31, 0x00, 0xF9,
+            0x28, 0x08, 0x00, 0xB0, 0x1B, 0x19, 0x05, 0xF9,
+            0x40, 0x1F, 0x00, 0xB4, 0xE1, 0x03, 0x1A, 0xAA,
+        ),
+        offset = 0,
+        replacement = ints(
+            0xE0, 0xEE, 0xFF, 0xB0, // adrp x0, #0x4a000
+            0x00, 0x7C, 0x24, 0x91, // add  x0, x0, #0x91f  -> &"unknown"
+            0xC8, 0x30, 0x00, 0xF0, // adrp x8, #0x888000
+            0x00, 0x31, 0x00, 0xF9, // str  x0, [x8, #0x60]
+            0x28, 0x08, 0x00, 0xB0, // adrp x8, #0x372000
+            0xFB, 0x00, 0x80, 0xD2, // movz x27, #7
+            0x1B, 0x19, 0x05, 0xF9, // str  x27, [x8, #0xa30]
+            0xE1, 0x03, 0x1A, 0xAA, // mov  x1, x26
+        ),
+    ),
+    // Export-path hash insert still loads the globals; keep a consumer-side pin so a missed writer
+    // call cannot re-null-deref. Points x1/w2 at the same "unknown"/7 pair before the bl.
     NativeProbePatch(
         label = "buildstamp-hash-export",
         signature = ints(
@@ -201,8 +221,13 @@ private val arm64NativeProbePatches = listOf(
             0x48, 0x08, 0x00, 0xB0, 0x02, 0x31, 0x4A, 0xB9,
             0x85, 0x80, 0xFE, 0x97,
         ),
-        offset = 12,
-        replacement = movW(register = 2, value = 0),
+        offset = 0,
+        replacement = ints(
+            0x01, 0xEF, 0xFF, 0xB0, // adrp x1, #0x4a000
+            0x21, 0x7C, 0x24, 0x91, // add  x1, x1, #0x91f
+            0xE2, 0x00, 0x80, 0x52, // movz w2, #7
+            0x1F, 0x20, 0x03, 0xD5, // nop
+        ),
     ),
     // Remaining *0x888060 byte-table loads not covered by the original probes (issue #114). Same
     // null pointer as above; these sites still do ldrb off it. 0x328 is a guard (cbnz into a fail
@@ -564,5 +589,26 @@ val unlockPremiumPatch = bytecodePatch(
             purchasedFlagStoreIndex,
             "const/4 v3, $FEATURE_PACKAGE_PURCHASED",
         )
+
+        // Settings export (issue #94). Export zips the temp SQLite dump then calls a static
+        // y([B)[B that Base64-encodes and hands the string to Sync.native_lock. After re-sign,
+        // native_lock returns null, y returns null, and the zip writer returns without writing
+        // so the SAF file stays 0 bytes. Pin is the unique "eS" acquire token used only here.
+        // Return the raw zip bytes so export is non-empty; import of that file still needs a
+        // matching native path if you re-import into stock Poweramp.
+        val exportCryptoHost = classDefByStrings("eS").singleOrNull()
+            ?: throw PatchException(
+                "Poweramp: export crypto host (string eS) not found. Re-derive the settings-export " +
+                    "pin for this build.",
+            )
+        val exportSeal = mutableClassDefBy(exportCryptoHost).methods.singleOrNull { method ->
+            AccessFlags.STATIC.isSet(method.accessFlags) &&
+                method.returnType == "[B" &&
+                method.parameterTypes == listOf("[B") &&
+                method.stringLiterals().contains("eS")
+        } ?: throw PatchException(
+            "Poweramp: export seal y([B)[B with eS not found. Re-derive the settings-export pin.",
+        )
+        exportSeal.addInstructions(0, "return-object p0")
     }
 }

--- a/patches/src/main/kotlin/hooman/morphe/patches/symfonium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/symfonium/UnlockPremiumPatch.kt
@@ -14,10 +14,10 @@ val unlockPremiumPatch = bytecodePatch(
         "trial: a license value the app keeps locally decides whether the paid UI is open, and two " +
         "timers (the beta cutoff and the trial countdown) lock the app once they pass. This forces the " +
         "license read to \"licensed\" so the paid screens open, drops the \"trial expires on ...\" line " +
-        "from settings, and stops the cutoff from triggering by cutting off the trusted-time lookup the " +
-        "timers rely on, which leaves the app in its offline state where neither timer fires. The " +
-        "license is checked on the client (a local Play purchase verify), so the unlock holds without " +
-        "an account. Connecting Plex, Jellyfin and other media servers is untouched.",
+        "from settings, and freezes the trusted-time lookup the timers read at a fixed pre-cutoff " +
+        "instant so neither timer can fire. The license is checked on the client (a local Play " +
+        "purchase verify), so the unlock holds without an account. Connecting Plex, Jellyfin and " +
+        "other media servers is untouched.",
 ) {
     compatibleWith(
         Compatibility(
@@ -70,16 +70,17 @@ val unlockPremiumPatch = bytecodePatch(
             """,
         )
 
-        // The SNTP fetch (er2.d). It is the sole source of the trusted wall-clock time that the beta
-        // cutoff and the trial countdown compare against, and its one caller swallows any failure and
-        // leaves the app on its "no trusted time" path, which never reports the build as expired. Make
-        // the fetch throw so that path is permanent; the timers can no longer fire.
+        // The SNTP fetch (er2.d), the sole source of the trusted wall-clock time the beta cutoff and
+        // trial countdown compare against. Return a fixed instant from before the build expiry
+        // (0x19eef33a600 = 2026-06-22 12:00 UTC) so both timers always read a pre-cutoff time and never
+        // fire. Do not throw here: the fetched time also feeds the media-resolution path, and an
+        // exception there corrupts stream-URL building (the provider host collapses to "1") and breaks
+        // playback. The method returns J, so return the constant wide.
         NetworkTimeFingerprint.method.addInstructions(
             0,
             """
-                new-instance v0, Ljava/lang/RuntimeException;
-                invoke-direct {v0}, Ljava/lang/RuntimeException;-><init>()V
-                throw v0
+                const-wide v0, 0x19eef33a600L
+                return-wide v0
             """,
         )
     }

--- a/patches/src/main/kotlin/hooman/morphe/patches/symfonium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/symfonium/UnlockPremiumPatch.kt
@@ -71,15 +71,16 @@ val unlockPremiumPatch = bytecodePatch(
         )
 
         // The SNTP fetch (er2.d), the sole source of the trusted wall-clock time the beta cutoff and
-        // trial countdown compare against. Return a fixed instant from before the build expiry
-        // (0x19eef33a600 = 2026-06-22 12:00 UTC) so both timers always read a pre-cutoff time and never
-        // fire. Do not throw here: the fetched time also feeds the media-resolution path, and an
-        // exception there corrupts stream-URL building (the provider host collapses to "1") and breaks
-        // playback. The method returns J, so return the constant wide.
+        // trial countdown compare against. Stock 14.1.0 bakes a beta cutoff at 0x19b76a3b980
+        // (2025-12-31 23:00 UTC). An earlier ship returned 0x19eef33a600 (2026-06-22), which is PAST
+        // that cutoff, so the beta wall still fired after provider setup. Return a fixed pre-cutoff
+        // instant (0x1972b5cee00 = 2025-06-01 12:00 UTC) so both timers always read "before expiry".
+        // Do not throw: the same trusted time feeds media-resolution URL building, and an exception
+        // there collapses the stream host to "1" and breaks playback.
         NetworkTimeFingerprint.method.addInstructions(
             0,
             """
-                const-wide v0, 0x19eef33a600L
+                const-wide v0, 0x1972b5cee00L
                 return-wide v0
             """,
         )


### PR DESCRIPTION
## Summary
- **Poweramp (#94 / #114):** stop settings-export SIGSEGV and 0-byte `.poweramp-settings` after re-sign. Native buildstamp probes keep settings from crashing; DEX bypass of `y([B)[B` / `Sync.native_lock` writes the raw zip when seal returns null.
- **Symfonium (#92):** SNTP fixed time was past the stock beta cutoff (2026-06-22 vs cutoff 2025-12-31). Return 2025-06-01 so the beta wall stays down after provider add without throwing (throw breaks stream host building).

## Emulator verify (Pixel_10_Pro)
- Symfonium: no "beta version has expired" after Navidrome/Subsonic setup
- Poweramp: export file **6977 bytes**, magic `PK\x03\x04`, process alive; Full Version / Thank you for purchase still shown
- `buildAndroid` + morphe-cli apply clean

## Notes
- Poweramp export is an unsealed zip (native seal skipped). Stock import of that file may still fail.
- Tracked/Quizlet/Alpha left out of this PR.

## Test plan
- [x] Build patches bundle
- [x] Apply Unlock Premium to Poweramp build-1025 universal + Symfonium 14.1.0
- [x] Emulator export gate + Full Version UI
- [x] Emulator Symfonium provider setup / no beta wall