### PR TITLE
fix: Quizlet Learn/Test meters, Tracked dashboard, Alpha Progression 7

### DIFF
--- a/patches/src/main/kotlin/hooman/morphe/patches/alphaprogression/premium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/alphaprogression/premium/UnlockPremiumPatch.kt
@@ -9,6 +9,9 @@ import app.morphe.patcher.patch.rawResourcePatch
  * Capacitor/Ionic app: feature logic lives in the JS bundle, not the DEX. Pro is one client-side
  * flag `proVersion.isActive`, read everywhere but written in only four places. All four are forced
  * truthy so it holds on the free-account paths (boot default and the not-entitled reset) too.
+ *
+ * 6.8.1 and 7.1.1 minify differently (dot vs bracket, literal vs obfuscated localStorage keys), so
+ * the four write sites are re-derived per shape. Bundle is located by content, not the hashed name.
  */
 @Suppress("unused")
 val unlockPremiumPatch = rawResourcePatch(
@@ -22,7 +25,10 @@ val unlockPremiumPatch = rawResourcePatch(
             name = "Alpha Progression",
             packageName = "com.alphaprogression.alphaprogression",
             appIconColor = 0x0091FF,
-            targets = listOf(AppTarget("6.8.1")),
+            targets = listOf(
+                AppTarget("6.8.1"),
+                AppTarget("7.1.1"),
+            ),
         ),
     )
 
@@ -35,38 +41,73 @@ val unlockPremiumPatch = rawResourcePatch(
             )
         }
 
-        // The bundle filename is content-hashed and changes every release, so find it by content.
-        val declaresState = "window.proVersion="
+        // Content-hashed filename changes every release; pick the bundle that owns proVersion state.
+        // 6.8.1: `window.proVersion=...`. 7.x: `window[obf]=JSON[parse](localStorage['getItem']('pro-version'))||{}`.
+        val bootV6 = "window.proVersion="
+        val bootV7 = "localStorage['getItem']('pro-version'))||{}"
         val bundles = (assetsDir.listFiles { file ->
             file.isFile && file.name.startsWith("index-") && file.name.endsWith(".js")
-        } ?: emptyArray()).filter { it.readText().contains(declaresState) }
+        } ?: emptyArray()).filter {
+            val text = it.readText()
+            text.contains(bootV6) || text.contains(bootV7)
+        }
         val bundle = bundles.singleOrNull()
             ?: throw PatchException(
-                "Expected exactly one JS bundle declaring `$declaresState`, found ${bundles.size}; " +
+                "Expected exactly one JS bundle declaring proVersion boot state, found ${bundles.size}; " +
                     "re-derive the anchors for this app version.",
             )
 
         var js = bundle.readText()
-
-        // Boot default: `window.proVersion = ... || {}`. Anchor on the unique declaration, then fix
-        // the first `||{}` after it (`||{}` alone occurs ~75x, so it can't be matched directly).
-        val init = js.indexOf(declaresState)
-        if (init < 0 || js.indexOf(declaresState, init + 1) >= 0) {
-            throw PatchException("`$declaresState` anchor missing or not unique; re-derive for this version.")
+        val isV7 = js.contains(bootV7)
+        val isV6 = js.contains(bootV6)
+        if (isV7 == isV6) {
+            throw PatchException(
+                "Could not tell 6.8.1 vs 7.x JS shape (v6=$isV6 v7=$isV7); re-derive for this version.",
+            )
         }
-        val emptyDefault = js.indexOf("||{}", init)
-        if (emptyDefault < 0 || emptyDefault - init > 160) {
-            throw PatchException("Boot-init default `||{}` not found after `$declaresState`; re-derive.")
-        }
-        js = js.substring(0, emptyDefault) + "||{isActive:!0}" + js.substring(emptyDefault + 4)
 
-        js = js.replaceOnce("(proVersion={})", "(proVersion={isActive:!0})", "free-reset")
-        js = js.replaceOnce("proVersion={isActive:i,", "proVersion={isActive:!0,", "trial")
-        js = js.replaceOnce(
-            "proVersion=a,localStorage.setItem(\"pro-version\"",
-            "proVersion=(a.isActive=!0,a),localStorage.setItem(\"pro-version\"",
-            "toggle-persist",
-        )
+        if (isV7) {
+            // 7.1.1 (obfuscator-io style): quoted keys, mangled locals, setItem via decode table.
+            js = js.replaceOnce(
+                bootV7,
+                "localStorage['getItem']('pro-version'))||{isActive:!0}",
+                "boot-default",
+            )
+            js = js.replaceOnce("(proVersion={})", "(proVersion={isActive:!0})", "free-reset")
+            // Trial / server-sub path in checkFree; value is a mangled local (_0x3085f2 on 7.1.1).
+            js = js.replaceOnce(
+                "proVersion={'isActive':_0x3085f2,",
+                "proVersion={'isActive':!0,",
+                "trial",
+            )
+            // toggle() persistence chokepoint: param is _0x2224d0 on 7.1.1.
+            js = js.replaceOnce(
+                "proVersion=_0x2224d0,localStorage",
+                "proVersion=(_0x2224d0.isActive=!0,_0x2224d0),localStorage",
+                "toggle-persist",
+            )
+        } else {
+            // 6.8.1: literal property access and setItem("pro-version", ...).
+            // Boot default: anchor on the unique declaration, then fix the first `||{}` after it
+            // (`||{}` alone occurs ~75x, so it can't be matched directly).
+            val init = js.indexOf(bootV6)
+            if (init < 0 || js.indexOf(bootV6, init + 1) >= 0) {
+                throw PatchException("`$bootV6` anchor missing or not unique; re-derive for this version.")
+            }
+            val emptyDefault = js.indexOf("||{}", init)
+            if (emptyDefault < 0 || emptyDefault - init > 160) {
+                throw PatchException("Boot-init default `||{}` not found after `$bootV6`; re-derive.")
+            }
+            js = js.substring(0, emptyDefault) + "||{isActive:!0}" + js.substring(emptyDefault + 4)
+
+            js = js.replaceOnce("(proVersion={})", "(proVersion={isActive:!0})", "free-reset")
+            js = js.replaceOnce("proVersion={isActive:i,", "proVersion={isActive:!0,", "trial")
+            js = js.replaceOnce(
+                "proVersion=a,localStorage.setItem(\"pro-version\"",
+                "proVersion=(a.isActive=!0,a),localStorage.setItem(\"pro-version\"",
+                "toggle-persist",
+            )
+        }
 
         bundle.writeText(js)
     }

--- a/patches/src/main/kotlin/hooman/morphe/patches/quizlet/premium/UnlockPlusPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/quizlet/premium/UnlockPlusPatch.kt
@@ -10,14 +10,15 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Suppress("unused")
 val unlockPlusPatch = bytecodePatch(
     name = "Unlock Plus",
     description = "Removes ads and unlocks the on-device Quizlet Plus features without a " +
-        "subscription, including unlimited Learn and Test rounds that free and Plus Limited " +
-        "accounts meter. The AI tools, like Magic Notes and generation, run on Quizlet's servers " +
-        "and stay locked.",
+        "subscription, including unlimited Learn and Test rounds and textbook explanation views " +
+        "that free accounts meter. The AI tools, like Magic Notes and generation, run on " +
+        "Quizlet's servers and stay locked.",
 ) {
     compatibleWith(
         Compatibility(
@@ -29,11 +30,24 @@ val unlockPlusPatch = bytecodePatch(
     )
 
     execute {
+        fun Method.stringLiterals(): Set<String> =
+            implementation?.instructions?.mapNotNull { instruction ->
+                (instruction as? ReferenceInstruction)?.reference
+                    ?.let { it as? StringReference }?.string
+            }?.toSet().orEmpty()
+
+        fun Method.returnVoidIndices(): List<Int> =
+            instructions
+                .withIndex()
+                .filter { it.value.opcode == Opcode.RETURN_VOID }
+                .map { it.index }
+                .sortedDescending()
+
         // Two local axes on DBUser (JSON/OrmLite; names survive R8):
         //   userUpgradeType: 0=NO_UPGRADE, 1=PLUS, 2=TEACHER, 3=GO
-        //   featurePlanType: plus_limited | plus_unlimited | plus_unlimited_teacher | family_plan
+        //   featurePlanType: plus_limited | plus_unlimited | ...
         // isFreeUser = (type == 0). Type alone kills ads but Learn/Test still meter free and
-        // plus_limited budgets, so mid-quiz subscribe walls still fire. Force GO + plus_unlimited.
+        // plus_limited budgets. Force GO + plus_unlimited.
         val dbUser = mutableClassDefByOrNull("Lcom/quizlet/db/data/models/persisted/DBUser;")
             ?: throw PatchException("Quizlet: DBUser class not found — model package changed.")
         val upgradeTypeGetter = dbUser.methods.firstOrNull { method ->
@@ -44,7 +58,6 @@ val unlockPlusPatch = bytecodePatch(
             ?: throw PatchException(
                 "Quizlet: DBUser.getUserUpgradeType()I not found — upgrade-type gate shape changed.",
             )
-        // GO (3) is the highest student upgrade type (PLUS=1 also badges as Plus).
         upgradeTypeGetter.addInstructions(
             0,
             """
@@ -85,25 +98,26 @@ val unlockPlusPatch = bytecodePatch(
             """,
         )
 
-        // Study-mode paywalls (Test start, set-page locks, Learn checkpoints) call MeteringInfo's
-        // at-limit / can-use booleans (numEvents vs threshold). Free accounts still get real counts
-        // from the server and local store, so the upgrade-type force above is not enough. Pin by the
-        // data-class toString prefix (unique vs Remote/Explanations variants); class name is R8-short.
-        val meteringInfoDefs = classDefByStrings("MeteringInfo(numEvents=")
-        val meteringInfoDef = meteringInfoDefs.singleOrNull()
-            ?: throw PatchException(
-                "Quizlet: MeteringInfo class not unique or missing " +
-                    "(found ${meteringInfoDefs.size}). Re-derive the metering pin.",
-            )
+        // Study-mode MeteringInfo (j2): at-limit g, can-use h. Call sites often IGET the fields
+        // instead of T()/c0(), so force fields at every return-void of the main ctor AND keep
+        // the accessors. Pin by exact toString prefix (not Remote/Explanations variants).
+        val meteringInfoDef = classDefByStrings("MeteringInfo(numEvents=").singleOrNull { def ->
+            def.methods.any { method ->
+                method.name == "toString" && method.stringLiterals().any {
+                    it.startsWith("MeteringInfo(numEvents=") &&
+                        !it.startsWith("Remote") &&
+                        !it.startsWith("Explanations")
+                }
+            }
+        } ?: throw PatchException(
+            "Quizlet: study MeteringInfo class not unique or missing. Re-derive the metering pin.",
+        )
         val meteringInfo = mutableClassDefBy(meteringInfoDef)
-
-        // Constructor writes g = (numEvents >= soft+threshold), then h = !g. Accessors T()/c0() each
-        // load one of those fields. Map write order -> force T false / c0 true.
-        val ctor = meteringInfo.methods.firstOrNull {
+        val meteringCtor = meteringInfo.methods.firstOrNull {
             it.name == "<init>" && it.parameterTypes.size >= 4
         } ?: throw PatchException("Quizlet: MeteringInfo constructor not found.")
         val writtenBoolFields = mutableListOf<String>()
-        for (instruction in ctor.instructions) {
+        for (instruction in meteringCtor.instructions) {
             if (instruction.opcode != Opcode.IPUT_BOOLEAN) continue
             val ref = (instruction as? ReferenceInstruction)?.reference as? FieldReference
                 ?: continue
@@ -167,9 +181,150 @@ val unlockPlusPatch = bytecodePatch(
                     "(atLimit=$forcedAtLimit, canUse=$forcedCanUse).",
             )
         }
+        // Field-level force: IGETs of g/h ignore the accessor patches.
+        // Do NOT use v0 here: many of these ctors are .locals 0, so v0 aliases p0 (this) and
+        // const/4 v0 clobbers this -> VerifyError "iput on BooleanConstant". Use p-registers.
+        // Also force numEvents/threshold args (p1/p2): Learn/Test hand j2.a/j2.b into shared
+        // MeteredEvent and re-evaluate limits there, ignoring the boolean flags.
+        meteringCtor.addInstructions(
+            0,
+            """
+                const/4 p1, 0x0
+                const/16 p2, 0x270f
+            """,
+        )
+        meteringCtor.returnVoidIndices().forEach { index ->
+            meteringCtor.addInstructions(
+                index,
+                """
+                    const/4 p1, 0x0
+                    iput-boolean p1, p0, ${meteringInfo.type}->$atLimitField:Z
+                    const/4 p1, 0x1
+                    iput-boolean p1, p0, ${meteringInfo.type}->$canUseField:Z
+                """,
+            )
+        }
 
-        // Some mid-quiz paths read StudiableMeteringData's remaining<=0 flag directly (stable
-        // package name). Force that single boolean field false at the end of the main constructor.
+        // Shared KMP MeteredEvent(numEvents, threshold) is what Learn/Test study engines meter on.
+        // Force every 2-int ctor to 0 / 9999 so mid-session increments and raw j2 copies stay open.
+        val meteredEventDef = classDefByStrings("MeteredEvent(numEvents=").singleOrNull()
+            ?: throw PatchException("Quizlet: MeteredEvent class not found.")
+        val meteredEvent = mutableClassDefBy(meteredEventDef)
+        for (ctor in meteredEvent.methods) {
+            if (ctor.name != "<init>" || ctor.returnType != "V") continue
+            // Public MeteredEvent(II): p1=numEvents, p2=threshold.
+            if (ctor.parameterTypes == listOf("I", "I")) {
+                ctor.addInstructions(
+                    0,
+                    """
+                        const/4 p1, 0x0
+                        const/16 p2, 0x270f
+                    """,
+                )
+            }
+            // kotlinx synthetic (mask, numEvents, threshold) uses p2/p3 for the ints.
+            if (ctor.parameterTypes == listOf("I", "I", "I")) {
+                ctor.addInstructions(
+                    0,
+                    """
+                        const/4 p2, 0x0
+                        const/16 p3, 0x270f
+                    """,
+                )
+            }
+        }
+
+        // PaywallContent carries canUseTestFeature / canUseLearnFeature. Force both true on the
+        // full 10-arg ctor (last two booleans) so set-page mode tiles unlock.
+        val paywallContentDef = classDefByStrings("PaywallContent(header=").singleOrNull {
+            it.methods.any { m ->
+                m.name == "toString" && m.stringLiterals().any { s -> s.contains("canUseLearnFeature=") }
+            }
+        }
+        if (paywallContentDef != null) {
+            val paywallContent = mutableClassDefBy(paywallContentDef)
+            val fullCtor = paywallContent.methods.firstOrNull {
+                it.name == "<init>" && it.parameterTypes.size == 10
+            }
+            if (fullCtor != null) {
+                // Params: g,I,I,a,a,Z,I,Z,Z,Z -> last two Z are canUseTest (p9) and canUseLearn (p10)
+                // Count slots carefully: g=1, I=1, I=1, a=1, a=1, Z=1, I=1, Z=1, Z=1, Z=1
+                // p0=this, p1..p10
+                fullCtor.addInstructions(
+                    0,
+                    """
+                        const/4 p9, 0x1
+                        const/4 p10, 0x1
+                    """,
+                )
+            }
+        }
+
+        // Textbook / explanation answers use ExplanationsMeteringInfo (k1). Force ctor inputs so
+        // computed atLimit is false and remaining is large: numEvents=0, threshold=9999.
+        val explanationsMeteringDef = classDefByStrings("ExplanationsMeteringInfo(numEvents=")
+            .singleOrNull()
+            ?: throw PatchException(
+                "Quizlet: ExplanationsMeteringInfo class not found. Re-derive textbook metering pin.",
+            )
+        val explanationsMetering = mutableClassDefBy(explanationsMeteringDef)
+        val expCtor = explanationsMetering.methods.firstOrNull {
+            it.name == "<init>" && it.parameterTypes.size == 2 && it.returnType == "V"
+        } ?: throw PatchException("Quizlet: ExplanationsMeteringInfo(II) constructor not found.")
+        expCtor.addInstructions(
+            0,
+            """
+                const/4 p1, 0x0
+                const/16 p2, 0x270f
+            """,
+        )
+
+        // QuestionDetailsWithMetering / ExerciseDetailsWithMetering: force isContentLimited arg
+        // (3rd param p3) false before the original iputs run.
+        for (limitedPin in listOf(
+            "QuestionDetailsWithMetering(question=",
+            "ExerciseDetailsWithMetering(exerciseDetails=",
+        )) {
+            val def = classDefByStrings(limitedPin).singleOrNull()
+                ?: throw PatchException("Quizlet: $limitedPin host class not found.")
+            val host = mutableClassDefBy(def)
+            val ctor = host.methods.firstOrNull {
+                it.name == "<init>" && it.parameterTypes.size == 3 && it.returnType == "V"
+            } ?: throw PatchException("Quizlet: $limitedPin 3-arg constructor not found.")
+            ctor.addInstructions(0, "const/4 p3, 0x0")
+        }
+
+        // Server entitlement payload: canUseFeature is the first ctor boolean (p1). Force true at
+        // entry so Moshi-built instances are usable without post-return iputs (which broke Verify).
+        val entitlementDef = classDefByStrings("RemoteEntitlementData(canUseFeature=")
+            .singleOrNull()
+            ?: throw PatchException("Quizlet: RemoteEntitlementData class not found.")
+        val entitlement = mutableClassDefBy(entitlementDef)
+        val entitlementCtor = entitlement.methods.firstOrNull {
+            it.name == "<init>" && it.parameterTypes.size == 4 && it.returnType == "V"
+        } ?: throw PatchException("Quizlet: RemoteEntitlementData constructor not found.")
+        entitlementCtor.addInstructions(0, "const/4 p1, 0x1")
+
+        // Unmetered(..., canUseFeature). Last param is Z; with eventType, Long, long (wide), reason,
+        // boolean the boolean lands in p6. Force true at entry.
+        val unmeteredDef = classDefByStrings("Unmetered(eventType=").singleOrNull()
+        if (unmeteredDef != null) {
+            val unmetered = mutableClassDefBy(unmeteredDef)
+            val unmeteredCtor = unmetered.methods.firstOrNull {
+                it.name == "<init>" && it.parameterTypes.size >= 4
+            }
+            // Prefer entry-arg force when the last param is boolean.
+            if (unmeteredCtor != null && unmeteredCtor.parameterTypes.lastOrNull() == "Z") {
+                // Count register slots: each J takes 2. p0=this.
+                var slot = 1
+                for (param in unmeteredCtor.parameterTypes.dropLast(1)) {
+                    slot += if (param == "J" || param == "D") 2 else 1
+                }
+                unmeteredCtor.addInstructions(0, "const/4 p$slot, 0x1")
+            }
+        }
+
+        // StudiableMeteringData: force at-limit false (+ remaining) at return using p1 as temp.
         val studiableMetering = mutableClassDefByOrNull(
             "Lcom/quizlet/studiablemodels/StudiableMeteringData;",
         ) ?: throw PatchException(
@@ -179,6 +334,9 @@ val unlockPlusPatch = bytecodePatch(
             ?: throw PatchException(
                 "Quizlet: StudiableMeteringData boolean at-limit field not unique.",
             )
+        val remainingSmdField = studiableMetering.fields.firstOrNull {
+            it.type == "Ljava/lang/Integer;" && it.name != "b" && it.name != "c"
+        } ?: studiableMetering.fields.lastOrNull { it.type == "Ljava/lang/Integer;" }
         val smdCtor = studiableMetering.methods.firstOrNull { method ->
             method.name == "<init>" &&
                 method.parameterTypes.size == 3 &&
@@ -186,18 +344,24 @@ val unlockPlusPatch = bytecodePatch(
         } ?: throw PatchException(
             "Quizlet: StudiableMeteringData(event, num, threshold) constructor not found.",
         )
-        val returnIndices = smdCtor.instructions
-            .withIndex()
-            .filter { it.value.opcode == Opcode.RETURN_VOID }
-            .map { it.index }
-            .sortedDescending()
-        if (returnIndices.isEmpty()) {
-            throw PatchException("Quizlet: StudiableMeteringData constructor has no return-void.")
-        }
-        returnIndices.forEach { index ->
+        smdCtor.returnVoidIndices().forEach { index ->
+            val remainingForce = if (remainingSmdField != null) {
+                """
+                    const/16 p1, 0x270f
+                    invoke-static {p1}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+                    move-result-object p1
+                    iput-object p1, p0, ${studiableMetering.type}->${remainingSmdField.name}:Ljava/lang/Integer;
+                """
+            } else {
+                ""
+            }
             smdCtor.addInstructions(
                 index,
-                "const/4 v0, 0x0\niput-boolean v0, p0, ${studiableMetering.type}->${atLimitSmdField.name}:Z",
+                """
+                    $remainingForce
+                    const/4 p1, 0x0
+                    iput-boolean p1, p0, ${studiableMetering.type}->${atLimitSmdField.name}:Z
+                """,
             )
         }
     }

--- a/patches/src/main/kotlin/hooman/morphe/patches/quizlet/premium/UnlockPlusPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/quizlet/premium/UnlockPlusPatch.kt
@@ -1,17 +1,23 @@
 package hooman.morphe.patches.quizlet.premium
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
 @Suppress("unused")
 val unlockPlusPatch = bytecodePatch(
     name = "Unlock Plus",
     description = "Removes ads and unlocks the on-device Quizlet Plus features without a " +
-        "subscription. The AI tools, like Magic Notes and generation, run on Quizlet's servers and " +
-        "stay locked.",
+        "subscription, including unlimited Learn and Test rounds that free and Plus Limited " +
+        "accounts meter. The AI tools, like Magic Notes and generation, run on Quizlet's servers " +
+        "and stay locked.",
 ) {
     compatibleWith(
         Compatibility(
@@ -23,10 +29,11 @@ val unlockPlusPatch = bytecodePatch(
     )
 
     execute {
-        // Plus and ads are decided on-device from DBUser.userUpgradeType (0=free, 1/3=Plus,
-        // 2=teacher); isFreeUser = (type == 0). DBUser is a JSON/OrmLite model so its names survive
-        // R8. Force the getter to PLUS(1) to flip isFreeUser false app-wide; server-side AI/metered
-        // features are unaffected. Pin by exact type, match the getter by shape; fail loudly if gone.
+        // Two local axes on DBUser (JSON/OrmLite; names survive R8):
+        //   userUpgradeType: 0=NO_UPGRADE, 1=PLUS, 2=TEACHER, 3=GO
+        //   featurePlanType: plus_limited | plus_unlimited | plus_unlimited_teacher | family_plan
+        // isFreeUser = (type == 0). Type alone kills ads but Learn/Test still meter free and
+        // plus_limited budgets, so mid-quiz subscribe walls still fire. Force GO + plus_unlimited.
         val dbUser = mutableClassDefByOrNull("Lcom/quizlet/db/data/models/persisted/DBUser;")
             ?: throw PatchException("Quizlet: DBUser class not found — model package changed.")
         val upgradeTypeGetter = dbUser.methods.firstOrNull { method ->
@@ -37,16 +44,32 @@ val unlockPlusPatch = bytecodePatch(
             ?: throw PatchException(
                 "Quizlet: DBUser.getUserUpgradeType()I not found — upgrade-type gate shape changed.",
             )
+        // GO (3) is the highest student upgrade type (PLUS=1 also badges as Plus).
         upgradeTypeGetter.addInstructions(
             0,
             """
-                const/4 v0, 0x1
+                const/4 v0, 0x3
                 return v0
             """,
         )
 
-        // Failsafe in case R8 inlined the getter at the free-user check: force isFreeUser(..) false
-        // if present. Best-effort, so don't fail the patch if obfuscation moved it.
+        val featurePlanTypeGetter = dbUser.methods.firstOrNull { method ->
+            method.name == "getFeaturePlanType" &&
+                method.returnType == "Ljava/lang/String;" &&
+                method.parameterTypes.isEmpty()
+        }
+            ?: throw PatchException(
+                "Quizlet: DBUser.getFeaturePlanType() not found — feature-plan gate shape changed.",
+            )
+        featurePlanTypeGetter.addInstructions(
+            0,
+            """
+                const-string v0, "plus_unlimited"
+                return-object v0
+            """,
+        )
+
+        // Failsafe if R8 inlined the getter at free-user checks. Best-effort.
         val isFreeUser = mutableClassDefByOrNull(
             "Lcom/quizlet/db/data/models/wrappers/LoggedInUserStatusKt;",
         )?.methods?.firstOrNull { method ->
@@ -61,5 +84,121 @@ val unlockPlusPatch = bytecodePatch(
                 return v0
             """,
         )
+
+        // Study-mode paywalls (Test start, set-page locks, Learn checkpoints) call MeteringInfo's
+        // at-limit / can-use booleans (numEvents vs threshold). Free accounts still get real counts
+        // from the server and local store, so the upgrade-type force above is not enough. Pin by the
+        // data-class toString prefix (unique vs Remote/Explanations variants); class name is R8-short.
+        val meteringInfoDefs = classDefByStrings("MeteringInfo(numEvents=")
+        val meteringInfoDef = meteringInfoDefs.singleOrNull()
+            ?: throw PatchException(
+                "Quizlet: MeteringInfo class not unique or missing " +
+                    "(found ${meteringInfoDefs.size}). Re-derive the metering pin.",
+            )
+        val meteringInfo = mutableClassDefBy(meteringInfoDef)
+
+        // Constructor writes g = (numEvents >= soft+threshold), then h = !g. Accessors T()/c0() each
+        // load one of those fields. Map write order -> force T false / c0 true.
+        val ctor = meteringInfo.methods.firstOrNull {
+            it.name == "<init>" && it.parameterTypes.size >= 4
+        } ?: throw PatchException("Quizlet: MeteringInfo constructor not found.")
+        val writtenBoolFields = mutableListOf<String>()
+        for (instruction in ctor.instructions) {
+            if (instruction.opcode != Opcode.IPUT_BOOLEAN) continue
+            val ref = (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                ?: continue
+            if (ref.definingClass == meteringInfo.type &&
+                ref.type == "Z" &&
+                ref.name !in writtenBoolFields
+            ) {
+                writtenBoolFields.add(ref.name)
+            }
+        }
+        if (writtenBoolFields.size < 2) {
+            throw PatchException(
+                "Quizlet: could not resolve MeteringInfo at-limit/can-use fields from constructor.",
+            )
+        }
+        val atLimitField = writtenBoolFields[0]
+        val canUseField = writtenBoolFields[1]
+
+        fun Method.loadedBooleanField(): String? {
+            for (instruction in instructions) {
+                if (instruction.opcode != Opcode.IGET_BOOLEAN) continue
+                val ref = (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: continue
+                if (ref.definingClass == meteringInfo.type && ref.type == "Z") {
+                    return ref.name
+                }
+            }
+            return null
+        }
+
+        var forcedAtLimit = false
+        var forcedCanUse = false
+        for (method in meteringInfo.methods) {
+            if (method.returnType != "Z" || method.parameterTypes.isNotEmpty()) continue
+            when (method.loadedBooleanField()) {
+                atLimitField -> {
+                    method.addInstructions(
+                        0,
+                        """
+                            const/4 v0, 0x0
+                            return v0
+                        """,
+                    )
+                    forcedAtLimit = true
+                }
+                canUseField -> {
+                    method.addInstructions(
+                        0,
+                        """
+                            const/4 v0, 0x1
+                            return v0
+                        """,
+                    )
+                    forcedCanUse = true
+                }
+            }
+        }
+        if (!forcedAtLimit || !forcedCanUse) {
+            throw PatchException(
+                "Quizlet: failed to force MeteringInfo at-limit/can-use accessors " +
+                    "(atLimit=$forcedAtLimit, canUse=$forcedCanUse).",
+            )
+        }
+
+        // Some mid-quiz paths read StudiableMeteringData's remaining<=0 flag directly (stable
+        // package name). Force that single boolean field false at the end of the main constructor.
+        val studiableMetering = mutableClassDefByOrNull(
+            "Lcom/quizlet/studiablemodels/StudiableMeteringData;",
+        ) ?: throw PatchException(
+            "Quizlet: StudiableMeteringData class not found — studiablemodels package changed.",
+        )
+        val atLimitSmdField = studiableMetering.fields.singleOrNull { it.type == "Z" }
+            ?: throw PatchException(
+                "Quizlet: StudiableMeteringData boolean at-limit field not unique.",
+            )
+        val smdCtor = studiableMetering.methods.firstOrNull { method ->
+            method.name == "<init>" &&
+                method.parameterTypes.size == 3 &&
+                method.returnType == "V"
+        } ?: throw PatchException(
+            "Quizlet: StudiableMeteringData(event, num, threshold) constructor not found.",
+        )
+        val returnIndices = smdCtor.instructions
+            .withIndex()
+            .filter { it.value.opcode == Opcode.RETURN_VOID }
+            .map { it.index }
+            .sortedDescending()
+        if (returnIndices.isEmpty()) {
+            throw PatchException("Quizlet: StudiableMeteringData constructor has no return-void.")
+        }
+        returnIndices.forEach { index ->
+            smdCtor.addInstructions(
+                index,
+                "const/4 v0, 0x0\niput-boolean v0, p0, ${studiableMetering.type}->${atLimitSmdField.name}:Z",
+            )
+        }
     }
 }

--- a/patches/src/main/kotlin/hooman/morphe/patches/tracked/pro/UnlockProPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tracked/pro/UnlockProPatch.kt
@@ -73,30 +73,47 @@ val unlockProPatch = rawResourcePatch(
         val patchAt = match + 8
         forceTrue.forEachIndexed { i, b -> bytes[patchAt + i] = b }
 
-        // Gate 2a: CustomizeDashboardRoute. Compares useSubscriptionTier.data === "free" and
-        // redirects free users to the paywall. Forcing the tier at its useQuery source is not a
-        // clean length-preserving edit, so flip the local StrictEq result to false.
-        // Anchor on GetByIdShort .data + LoadConstString "free"(42004) + StrictEq (unique).
-        val dashboardSignature = intArrayOf(
-            0x44, 0x07, 0x04, 0x04, 0x67,       // GetByIdShort r7, r4, 4, "data"
-            0x90, 0x04, 0x14, 0xA4,             // LoadConstString r4, 42004 ("free")
-            0x17, 0x03, 0x07, 0x04,             // StrictEq r3, r7, r4        <- patch target (offset 9)
-        ).map { it.toByte() }.toByteArray()
-
-        val dashboardMatch = bytes.findUnique(dashboardSignature)
-            ?: throw PatchException(
-                "Customize-dashboard gate signature not found in $bundlePath. This patch targets " +
-                    "Tracked 7.0.0 (Hermes bytecode v98); the bundle likely changed in a newer build " +
-                    "and the signature must be re-derived.",
+        // Gate 2a: useSubscriptionTier.data === "free" StrictEq sites. CustomizeDashboardRoute is
+        // one; CustomizeDashboardButton / related UI uses a second GetByIdShort+.data+free run with
+        // different registers. Force every unique GetByIdShort + free(42004) + StrictEq so isFree
+        // never redirects to the paywall. Each StrictEq is 4 bytes: LoadConstFalse dest + Jmp +2.
+        // Pattern is the 4-byte StrictEq after free, not the whole GetById (regs vary).
+        // free string id 42004 = 0xA414 little-endian after LoadConstString (0x90).
+        val freeStrictEqSites = mutableListOf<Int>()
+        var scan = 0
+        while (scan < bytes.size - 8) {
+            // LoadConstString rX, 42004  => 90 rX 14 A4
+            if (bytes[scan] == 0x90.toByte() &&
+                bytes[scan + 2] == 0x14.toByte() &&
+                bytes[scan + 3] == 0xA4.toByte() &&
+                bytes[scan + 4] == 0x17.toByte()
+            ) {
+                // StrictEq rD, rA, rB at scan+4. Require a nearby GetByIdShort (0x44) before free.
+                val lookback = bytes.copyOfRange((scan - 12).coerceAtLeast(0), scan)
+                if (lookback.any { it == 0x44.toByte() }) {
+                    freeStrictEqSites.add(scan + 4)
+                }
+            }
+            scan++
+        }
+        if (freeStrictEqSites.isEmpty()) {
+            throw PatchException(
+                "No useSubscriptionTier free StrictEq sites found in $bundlePath. This patch " +
+                    "targets Tracked 7.0.0 (Hermes bytecode v98); re-derive free-tier pins.",
             )
-
-        // Replace `StrictEq r3, r7, r4` (4 bytes) with `LoadConstFalse r3` + `Jmp +2`: r3 (the isFree
-        // flag) is always false, so the JmpTrue that redirects free users to the paywall never fires.
-        //   96 03  LoadConstFalse r3
-        //   AE 02  Jmp +2  (falls through to the original StoreNPToEnvironment)
-        val forceFalse = intArrayOf(0x96, 0x03, 0xAE, 0x02).map { it.toByte() }
-        val dashboardPatchAt = dashboardMatch + 9
-        forceFalse.forEachIndexed { i, b -> bytes[dashboardPatchAt + i] = b }
+        }
+        for (strictEqAt in freeStrictEqSites) {
+            // StrictEq encoding: 17 dest left right — force dest false.
+            val destReg = bytes[strictEqAt + 1].toInt() and 0xFF
+            // LoadConstFalse rDest (0x96 r) is 2 bytes; Jmp +2 (0xAE 0x02) is 2 bytes.
+            if (destReg > 0xFF) {
+                throw PatchException("Tracked free StrictEq dest register out of range at $strictEqAt")
+            }
+            bytes[strictEqAt] = 0x96.toByte()
+            bytes[strictEqAt + 1] = destReg.toByte()
+            bytes[strictEqAt + 2] = 0xAE.toByte()
+            bytes[strictEqAt + 3] = 0x02.toByte()
+        }
 
         // Gate 2b: SessionEndStats isPro. Density and Net Progression on the workout summary both
         // read env slot isPro = (tier==="pro" || tier==="pro_plus") from useSubscriptionTier; free

--- a/patches/src/main/kotlin/hooman/morphe/patches/tracked/pro/UnlockProPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tracked/pro/UnlockProPatch.kt
@@ -6,17 +6,21 @@ import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.rawResourcePatch
 
 // Tracked is React Native (Expo): the Pro logic is Hermes bytecode in
-// assets/index.android.bundle, not the DEX. The async isProSubscriptionActive resolves true when the
-// RevenueCat tier is "pro" or "pro_plus", and every Pro gate reads it (~40 sites), so forcing it true
-// unlocks them all. Offsets shift between releases, so anchor on a byte signature around the
-// "pro"/"pro_plus" comparison and refuse to patch unless it matches exactly once.
+// assets/index.android.bundle, not the DEX. Two independent entitlement sources:
+//   1. isProSubscriptionActive (RevenueCat "pro"/"pro_plus") -- ~40 call sites
+//   2. useSubscriptionTier (server-fetched useQuery, defaults "free") -- separate
+//      readers that never touch (1). CustomizeDashboardRoute compares tier==="free";
+//      SessionEndStats builds isPro from tier==="pro"||"pro_plus" for Density and
+//      Net Progression on the workout summary.
+// Offsets shift between releases, so each edit anchors on a unique byte signature
+// and refuses to patch unless it matches exactly once.
 @Suppress("unused")
 val unlockProPatch = rawResourcePatch(
     name = "Unlock Pro",
     description = "Unlocks Tracked's premium training tools without a subscription, like muscle " +
-        "analytics and training programs. They run on the workout data already on your device, so " +
-        "they keep working offline. The separate human-coaching marketplace still needs its own " +
-        "subscription.",
+        "analytics, training programs, dashboard customization, and session density/net " +
+        "progression. They run on the workout data already on your device, so they keep working " +
+        "offline. The separate human-coaching marketplace still needs its own subscription.",
 ) {
     compatibleWith(
         Compatibility(
@@ -37,9 +41,12 @@ val unlockProPatch = rawResourcePatch(
             )
         }
 
-        // Hermes lowers `tier === "pro" || tier === "pro_plus"` into the run below; the first StrictEq
-        // (the byte we overwrite) leaves r7, which is what the Promise resolves to. The embedded string
-        // ids for "pro" (31262) and "pro_plus" (78734) make the run unique in the bundle.
+        val bytes = bundle.readBytes()
+
+        // Gate 1: isProSubscriptionActive. Hermes lowers
+        // `tier === "pro" || tier === "pro_plus"` into the run below; the first StrictEq
+        // (the byte we overwrite) leaves r7, which is what the Promise resolves to. The embedded
+        // string ids for "pro" (31262) and "pro_plus" (78734) make the run unique in the bundle.
         val signature = intArrayOf(
             0x3B, 0x08, 0x05, 0x00,             // LoadFromEnvironment r8, r5, 0
             0x90, 0x07, 0x1E, 0x7A,             // LoadConstString r7, 31262 ("pro")
@@ -50,7 +57,6 @@ val unlockProPatch = rawResourcePatch(
             0x17, 0x07, 0x08, 0x05,             // StrictEq r7, r8, r5
         ).map { it.toByte() }.toByteArray()
 
-        val bytes = bundle.readBytes()
         val match = bytes.findUnique(signature)
             ?: throw PatchException(
                 "Pro-gate signature not found in $bundlePath. This patch targets Tracked 7.0.0 " +
@@ -66,6 +72,59 @@ val unlockProPatch = rawResourcePatch(
         val forceTrue = intArrayOf(0x95, 0x07, 0xAE, 0x02).map { it.toByte() }
         val patchAt = match + 8
         forceTrue.forEachIndexed { i, b -> bytes[patchAt + i] = b }
+
+        // Gate 2a: CustomizeDashboardRoute. Compares useSubscriptionTier.data === "free" and
+        // redirects free users to the paywall. Forcing the tier at its useQuery source is not a
+        // clean length-preserving edit, so flip the local StrictEq result to false.
+        // Anchor on GetByIdShort .data + LoadConstString "free"(42004) + StrictEq (unique).
+        val dashboardSignature = intArrayOf(
+            0x44, 0x07, 0x04, 0x04, 0x67,       // GetByIdShort r7, r4, 4, "data"
+            0x90, 0x04, 0x14, 0xA4,             // LoadConstString r4, 42004 ("free")
+            0x17, 0x03, 0x07, 0x04,             // StrictEq r3, r7, r4        <- patch target (offset 9)
+        ).map { it.toByte() }.toByteArray()
+
+        val dashboardMatch = bytes.findUnique(dashboardSignature)
+            ?: throw PatchException(
+                "Customize-dashboard gate signature not found in $bundlePath. This patch targets " +
+                    "Tracked 7.0.0 (Hermes bytecode v98); the bundle likely changed in a newer build " +
+                    "and the signature must be re-derived.",
+            )
+
+        // Replace `StrictEq r3, r7, r4` (4 bytes) with `LoadConstFalse r3` + `Jmp +2`: r3 (the isFree
+        // flag) is always false, so the JmpTrue that redirects free users to the paywall never fires.
+        //   96 03  LoadConstFalse r3
+        //   AE 02  Jmp +2  (falls through to the original StoreNPToEnvironment)
+        val forceFalse = intArrayOf(0x96, 0x03, 0xAE, 0x02).map { it.toByte() }
+        val dashboardPatchAt = dashboardMatch + 9
+        forceFalse.forEachIndexed { i, b -> bytes[dashboardPatchAt + i] = b }
+
+        // Gate 2b: SessionEndStats isPro. Density and Net Progression on the workout summary both
+        // read env slot isPro = (tier==="pro" || tier==="pro_plus") from useSubscriptionTier; free
+        // users get a PRO badge and onPress navigates to the paywall. Force the first StrictEq true
+        // so the existing JmpTrue always takes the is-pro store path. Unique 19-byte run around the
+        // pro/pro_plus compare with registers r15/r6/r17.
+        val sessionIsProSignature = intArrayOf(
+            0x90, 0x0F, 0x1E, 0x7A,             // LoadConstString r15, 31262 ("pro")
+            0x17, 0x06, 0x11, 0x0F,             // StrictEq r6, r17, r15     <- patch target (offset 4)
+            0xB0, 0x0D, 0x06,                   // JmpTrue +13, r6
+            0x91, 0x0F, 0x8E, 0x33, 0x01, 0x00, // LoadConstStringLongIndex r15, 78734 ("pro_plus")
+            0x17, 0x06, 0x11, 0x0F,             // StrictEq r6, r17, r15
+        ).map { it.toByte() }.toByteArray()
+
+        val sessionMatch = bytes.findUnique(sessionIsProSignature)
+            ?: throw PatchException(
+                "Session-end isPro gate signature not found in $bundlePath. This patch targets " +
+                    "Tracked 7.0.0 (Hermes bytecode v98); the bundle likely changed in a newer build " +
+                    "and the signature must be re-derived.",
+            )
+
+        // Replace `StrictEq r6, r17, r15` with `LoadConstTrue r6` + `Jmp +2`; the following JmpTrue
+        // then always stores isPro=true for Density/Net Progression.
+        //   95 06  LoadConstTrue r6
+        //   AE 02  Jmp +2
+        val forceSessionTrue = intArrayOf(0x95, 0x06, 0xAE, 0x02).map { it.toByte() }
+        val sessionPatchAt = sessionMatch + 4
+        forceSessionTrue.forEachIndexed { i, b -> bytes[sessionPatchAt + i] = b }
 
         bundle.writeBytes(bytes)
     }


### PR DESCRIPTION
## Summary
- **Quizlet (#105):** Unlock Plus now covers Learn/Test free meters (raw `MeteredEvent` numEvents/threshold + study MeteringInfo + PaywallContent learn/test flags), textbook `ExplanationsMeteringInfo`, and related entitlement/content-limited fields. Device-verified: textbooks + Learn/Test work on 10.38.1.
- **Tracked (#98):** Unlock Pro forces all useSubscriptionTier free StrictEq sites after GetByIdShort `.data` (customize dashboard) plus session-end isPro. Device-verified: customize dashboard works on 7.0.0.
- **Alpha Progression (#75):** Unlock Premium dual-path JS anchors for 7.1.1 (obfuscator-io). Device-verified earlier this session.

## Test plan
- [x] Quizlet 10.38.1: textbook answers, Learn, Test past free wall (Pixel 9 Pro XL)
- [x] Tracked 7.0.0: customize dashboard
- [x] Alpha Progression 7.1.1: Pro unlock
- [x] buildAndroid + morphe-cli apply clean

## Notes
- Quizlet AI/Magic Notes remain server-side.
- Tracked coaching marketplace remains server-side.