### PR TITLE
feat: update app targets and add Twitch emotes + Tumblr screenshot patches

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: '17'
 
       - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: '21'
 
       - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    alias(libs.plugins.android.library) apply false
+}

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -1,0 +1,3 @@
+-keep class app.morphe.extension.twitch.emotes.EmoteSupport {
+    public static *;
+}

--- a/extensions/twitch/build.gradle.kts
+++ b/extensions/twitch/build.gradle.kts
@@ -1,0 +1,15 @@
+import com.android.build.api.dsl.ApplicationExtension
+
+configure<ApplicationExtension> {
+    namespace = "app.morphe.extension.twitch"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/extensions/twitch/src/main/AndroidManifest.xml
+++ b/extensions/twitch/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest/>

--- a/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/CenteredImageSpan.java
+++ b/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/CenteredImageSpan.java
@@ -1,0 +1,85 @@
+package app.morphe.extension.twitch.emotes;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.drawable.Animatable;
+import android.graphics.drawable.Drawable;
+import android.text.style.DynamicDrawableSpan;
+import android.widget.TextView;
+
+final class CenteredImageSpan extends DynamicDrawableSpan {
+    private final Drawable drawable;
+    private final Paint.FontMetricsInt paintMetrics = new Paint.FontMetricsInt();
+
+    CenteredImageSpan(TextView textView, Drawable drawable) {
+        super(ALIGN_BOTTOM);
+        this.drawable = drawable;
+
+        int height = Math.max(1, Math.round(textView.getTextSize() * 1.25f));
+        int intrinsicHeight = drawable.getIntrinsicHeight();
+        int intrinsicWidth = drawable.getIntrinsicWidth();
+        int width = intrinsicHeight > 0 && intrinsicWidth > 0
+                ? Math.max(1, Math.round((float) intrinsicWidth * height / intrinsicHeight))
+                : height;
+        drawable.setBounds(0, 0, width, height);
+        drawable.setCallback(textView);
+        if (drawable instanceof Animatable) {
+            ((Animatable) drawable).start();
+        }
+    }
+
+    @Override
+    public Drawable getDrawable() {
+        return drawable;
+    }
+
+    @Override
+    public int getSize(
+            Paint paint,
+            CharSequence text,
+            int start,
+            int end,
+            Paint.FontMetricsInt metrics
+    ) {
+        Rect bounds = drawable.getBounds();
+        if (metrics != null) {
+            paint.getFontMetricsInt(paintMetrics);
+            int center = (paintMetrics.ascent + paintMetrics.descent) / 2;
+            int halfHeight = bounds.height() / 2;
+            metrics.ascent = center - halfHeight;
+            metrics.top = metrics.ascent;
+            metrics.descent = center + halfHeight;
+            metrics.bottom = metrics.descent;
+        }
+        return bounds.width();
+    }
+
+    @Override
+    public void draw(
+            Canvas canvas,
+            CharSequence text,
+            int start,
+            int end,
+            float x,
+            int top,
+            int baseline,
+            int bottom,
+            Paint paint
+    ) {
+        paint.getFontMetricsInt(paintMetrics);
+        int textCenter = baseline + (paintMetrics.ascent + paintMetrics.descent) / 2;
+        int drawableTop = textCenter - drawable.getBounds().height() / 2;
+        canvas.save();
+        canvas.translate(x, drawableTop);
+        drawable.draw(canvas);
+        canvas.restore();
+    }
+
+    void stop() {
+        if (drawable instanceof Animatable) {
+            ((Animatable) drawable).stop();
+        }
+        drawable.setCallback(null);
+    }
+}

--- a/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/Emote.java
+++ b/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/Emote.java
@@ -1,0 +1,13 @@
+package app.morphe.extension.twitch.emotes;
+
+final class Emote {
+    final String name;
+    final String url;
+    final boolean animated;
+
+    Emote(String name, String url, boolean animated) {
+        this.name = name;
+        this.url = url;
+        this.animated = animated;
+    }
+}

--- a/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteCatalog.java
+++ b/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteCatalog.java
@@ -1,0 +1,460 @@
+package app.morphe.extension.twitch.emotes;
+
+import android.content.Context;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+final class EmoteCatalog {
+    private static final long CACHE_TTL_MS = 6L * 60L * 60L * 1000L;
+    private static final long RETRY_BACKOFF_MS = 5L * 60L * 1000L;
+    private static final int MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+    private static final int MAX_CHANNEL_CATALOGS = 32;
+    private static final String USER_AGENT = "HoomanMorpheTwitchEmotes/1.0";
+
+    private final Object channelCacheLock = new Object();
+    private final LinkedHashMap<String, ChannelState> channels =
+            new LinkedHashMap<>(16, 0.75f, true);
+    private final ProviderState globalSevenTv = new ProviderState();
+    private final ProviderState globalBetterTtv = new ProviderState();
+    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+            2,
+            2,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(64),
+            new DaemonThreadFactory()
+    );
+    private final Consumer<String> onUpdated;
+
+    EmoteCatalog(Consumer<String> onUpdated) {
+        this.onUpdated = onUpdated;
+    }
+
+    void ensureLoaded(Context context, String channelId) {
+        Context applicationContext = context.getApplicationContext();
+        long now = System.currentTimeMillis();
+        schedule(globalSevenTv, now, () -> loadGlobalSevenTv(applicationContext));
+        schedule(globalBetterTtv, now, () -> loadGlobalBetterTtv(applicationContext));
+
+        if (channelId == null) {
+            return;
+        }
+        ChannelState channel = getChannel(channelId, true);
+        schedule(channel.sevenTv, now, () -> loadChannelSevenTv(applicationContext, channelId, channel));
+        schedule(channel.betterTtv, now,
+                () -> loadChannelBetterTtv(applicationContext, channelId, channel));
+    }
+
+    Emote find(String channelId, String name) {
+        if (channelId != null) {
+            ChannelState channel = getChannel(channelId, false);
+            if (channel != null) {
+                Emote emote = channel.sevenTv.emotes.get(name);
+                if (emote != null) {
+                    return emote;
+                }
+                emote = channel.betterTtv.emotes.get(name);
+                if (emote != null) {
+                    return emote;
+                }
+            }
+        }
+        Emote emote = globalSevenTv.emotes.get(name);
+        return emote == null ? globalBetterTtv.emotes.get(name) : emote;
+    }
+
+    private void schedule(ProviderState state, long now, Runnable load) {
+        if (!state.needsRefresh(now) || !state.loading.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            executor.execute(load);
+        } catch (RejectedExecutionException ignored) {
+            state.loading.set(false);
+            state.retryAfter = now + RETRY_BACKOFF_MS;
+        }
+    }
+
+    private void loadGlobalSevenTv(Context context) {
+        boolean updated = false;
+        try {
+            LoadedValue<JSONObject> response = loadJson(
+                    context,
+                    "7tv-global",
+                    "https://7tv.io/v3/emote-sets/global"
+            );
+            Map<String, Emote> loaded = new LinkedHashMap<>();
+            parseSevenTv(response.value, loaded);
+            globalSevenTv.publish(loaded, response.fresh);
+            updated = true;
+        } catch (Exception ignored) {
+            globalSevenTv.failed();
+        } finally {
+            globalSevenTv.loading.set(false);
+        }
+        if (updated) {
+            onUpdated.accept(null);
+        }
+    }
+
+    private void loadGlobalBetterTtv(Context context) {
+        boolean updated = false;
+        try {
+            LoadedValue<JSONArray> response = loadJsonArray(
+                    context,
+                    "bttv-global",
+                    "https://api.betterttv.net/3/cached/emotes/global"
+            );
+            Map<String, Emote> loaded = new LinkedHashMap<>();
+            parseBetterTtvArray(response.value, loaded);
+            globalBetterTtv.publish(loaded, response.fresh);
+            updated = true;
+        } catch (Exception ignored) {
+            globalBetterTtv.failed();
+        } finally {
+            globalBetterTtv.loading.set(false);
+        }
+        if (updated) {
+            onUpdated.accept(null);
+        }
+    }
+
+    private void loadChannelSevenTv(Context context, String channelId, ChannelState channel) {
+        boolean updated = false;
+        try {
+            LoadedValue<JSONObject> response = loadOptionalJson(
+                    context,
+                    "7tv-channel-" + channelId,
+                    "https://7tv.io/v3/users/twitch/" + channelId
+            );
+            Map<String, Emote> loaded = new LinkedHashMap<>();
+            JSONObject set = response.value.optJSONObject("emote_set");
+            if (set != null) {
+                parseSevenTv(set, loaded);
+            }
+            channel.sevenTv.publish(loaded, response.fresh);
+            updated = true;
+        } catch (Exception ignored) {
+            channel.sevenTv.failed();
+        } finally {
+            channel.sevenTv.loading.set(false);
+        }
+        if (updated) {
+            onUpdated.accept(channelId);
+        }
+    }
+
+    private void loadChannelBetterTtv(Context context, String channelId, ChannelState channel) {
+        boolean updated = false;
+        try {
+            LoadedValue<JSONObject> response = loadOptionalJson(
+                    context,
+                    "bttv-channel-" + channelId,
+                    "https://api.betterttv.net/3/cached/users/twitch/" + channelId
+            );
+            Map<String, Emote> loaded = new LinkedHashMap<>();
+            parseBetterTtvArray(response.value.optJSONArray("channelEmotes"), loaded);
+            parseBetterTtvArray(response.value.optJSONArray("sharedEmotes"), loaded);
+            channel.betterTtv.publish(loaded, response.fresh);
+            updated = true;
+        } catch (Exception ignored) {
+            channel.betterTtv.failed();
+        } finally {
+            channel.betterTtv.loading.set(false);
+        }
+        if (updated) {
+            onUpdated.accept(channelId);
+        }
+    }
+
+    private ChannelState getChannel(String channelId, boolean create) {
+        synchronized (channelCacheLock) {
+            ChannelState channel = channels.get(channelId);
+            if (channel == null && create) {
+                channel = new ChannelState();
+                channels.put(channelId, channel);
+                while (channels.size() > MAX_CHANNEL_CATALOGS) {
+                    String oldest = channels.keySet().iterator().next();
+                    channels.remove(oldest);
+                }
+            }
+            return channel;
+        }
+    }
+
+    private static void parseSevenTv(JSONObject root, Map<String, Emote> target)
+            throws JSONException {
+        JSONArray emotes = root.optJSONArray("emotes");
+        if (emotes == null) {
+            return;
+        }
+        for (int index = 0; index < emotes.length(); index++) {
+            JSONObject item = emotes.optJSONObject(index);
+            if (item == null || (item.optInt("flags", 0) & 1) != 0) {
+                continue;
+            }
+            String name = item.optString("name", "");
+            JSONObject data = item.optJSONObject("data");
+            JSONObject host = data == null ? null : data.optJSONObject("host");
+            String hostUrl = host == null ? "" : host.optString("url", "");
+            JSONArray files = host == null ? null : host.optJSONArray("files");
+            String fileName = chooseSevenTvFile(files);
+            if (name.isEmpty() || hostUrl.isEmpty() || fileName == null) {
+                continue;
+            }
+            if (hostUrl.startsWith("//")) {
+                hostUrl = "https:" + hostUrl;
+            } else if (!hostUrl.startsWith("http://") && !hostUrl.startsWith("https://")) {
+                hostUrl = "https://" + hostUrl;
+            }
+            String url = hostUrl.endsWith("/") ? hostUrl + fileName : hostUrl + "/" + fileName;
+            target.put(name, new Emote(name, url, data != null && data.optBoolean("animated", false)));
+        }
+    }
+
+    private static String chooseSevenTvFile(JSONArray files) {
+        if (files == null) {
+            return null;
+        }
+        String fallback = null;
+        for (int index = 0; index < files.length(); index++) {
+            JSONObject file = files.optJSONObject(index);
+            if (file == null || !"WEBP".equalsIgnoreCase(file.optString("format"))) {
+                continue;
+            }
+            String name = file.optString("name", "");
+            if (name.isEmpty()) {
+                continue;
+            }
+            if ("2x.webp".equalsIgnoreCase(name)) {
+                return name;
+            }
+            fallback = name;
+        }
+        return fallback;
+    }
+
+    private static void parseBetterTtvArray(JSONArray emotes, Map<String, Emote> target) {
+        if (emotes == null) {
+            return;
+        }
+        for (int index = 0; index < emotes.length(); index++) {
+            JSONObject item = emotes.optJSONObject(index);
+            if (item == null) {
+                continue;
+            }
+            String id = item.optString("id", "");
+            String name = item.optString("code", "");
+            if (id.isEmpty() || name.isEmpty()) {
+                continue;
+            }
+            target.put(name, new Emote(
+                    name,
+                    "https://cdn.betterttv.net/emote/" + id + "/2x.webp",
+                    item.optBoolean("animated", false)
+            ));
+        }
+    }
+
+    private static LoadedValue<JSONObject> loadJson(Context context, String cacheKey, String url)
+            throws IOException, JSONException {
+        LoadedValue<String> text = loadText(context, cacheKey, url, false);
+        try {
+            return new LoadedValue<>(new JSONObject(text.value), text.fresh);
+        } catch (JSONException failure) {
+            deleteCachedText(context, cacheKey);
+            throw failure;
+        }
+    }
+
+    private static LoadedValue<JSONObject> loadOptionalJson(
+            Context context,
+            String cacheKey,
+            String url
+    ) throws IOException, JSONException {
+        LoadedValue<String> text = loadText(context, cacheKey, url, true);
+        try {
+            return new LoadedValue<>(new JSONObject(text.value), text.fresh);
+        } catch (JSONException failure) {
+            deleteCachedText(context, cacheKey);
+            throw failure;
+        }
+    }
+
+    private static LoadedValue<JSONArray> loadJsonArray(Context context, String cacheKey, String url)
+            throws IOException, JSONException {
+        LoadedValue<String> text = loadText(context, cacheKey, url, false);
+        try {
+            return new LoadedValue<>(new JSONArray(text.value), text.fresh);
+        } catch (JSONException failure) {
+            deleteCachedText(context, cacheKey);
+            throw failure;
+        }
+    }
+
+    private static void deleteCachedText(Context context, String cacheKey) {
+        File cache = new File(new File(context.getCacheDir(), "morphe_emote_catalog"),
+                cacheKey + ".json");
+        //noinspection ResultOfMethodCallIgnored
+        cache.delete();
+    }
+
+    private static LoadedValue<String> loadText(
+            Context context,
+            String cacheKey,
+            String url,
+            boolean allowNotFound
+    ) throws IOException {
+        File directory = new File(context.getCacheDir(), "morphe_emote_catalog");
+        File cache = new File(directory, cacheKey + ".json");
+        long now = System.currentTimeMillis();
+        if (cache.isFile() && now - cache.lastModified() <= CACHE_TTL_MS) {
+            try {
+                return new LoadedValue<>(readText(cache), true);
+            } catch (IOException ignored) {
+                //noinspection ResultOfMethodCallIgnored
+                cache.delete();
+            }
+        }
+
+        try {
+            String result = request(url, allowNotFound);
+            if (directory.isDirectory() || directory.mkdirs()) {
+                writeText(cache, result);
+            }
+            return new LoadedValue<>(result, true);
+        } catch (IOException failure) {
+            if (cache.isFile()) {
+                return new LoadedValue<>(readText(cache), false);
+            }
+            throw failure;
+        }
+    }
+
+    private static String request(String url, boolean allowNotFound) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setConnectTimeout(7_000);
+        connection.setReadTimeout(10_000);
+        connection.setRequestProperty("Accept", "application/json");
+        connection.setRequestProperty("User-Agent", USER_AGENT);
+        try {
+            int status = connection.getResponseCode();
+            if (allowNotFound && status == HttpURLConnection.HTTP_NOT_FOUND) {
+                return "{}";
+            }
+            if (status < 200 || status >= 300) {
+                throw new IOException("HTTP " + status + " for " + url);
+            }
+            try (InputStream input = connection.getInputStream()) {
+                return new String(readLimited(input, MAX_RESPONSE_BYTES), StandardCharsets.UTF_8);
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static String readText(File file) throws IOException {
+        try (InputStream input = new FileInputStream(file)) {
+            return new String(readLimited(input, MAX_RESPONSE_BYTES), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static byte[] readLimited(InputStream input, int limit) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8_192];
+        int total = 0;
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            total += read;
+            if (total > limit) {
+                throw new IOException("Response exceeds " + limit + " bytes");
+            }
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private static void writeText(File file, String text) throws IOException {
+        File temporary = new File(file.getParentFile(), file.getName() + ".tmp");
+        try (FileOutputStream output = new FileOutputStream(temporary)) {
+            output.write(text.getBytes(StandardCharsets.UTF_8));
+        }
+        if (!temporary.renameTo(file)) {
+            try (FileOutputStream output = new FileOutputStream(file)) {
+                output.write(text.getBytes(StandardCharsets.UTF_8));
+            }
+            //noinspection ResultOfMethodCallIgnored
+            temporary.delete();
+        }
+    }
+
+    private static final class ProviderState {
+        final AtomicBoolean loading = new AtomicBoolean();
+        volatile Map<String, Emote> emotes = Collections.emptyMap();
+        volatile long loadedAt;
+        volatile long retryAfter;
+
+        boolean needsRefresh(long now) {
+            return now >= retryAfter && (loadedAt == 0L || now - loadedAt >= CACHE_TTL_MS);
+        }
+
+        void publish(Map<String, Emote> loaded, boolean fresh) {
+            long now = System.currentTimeMillis();
+            emotes = Collections.unmodifiableMap(loaded);
+            loadedAt = fresh ? now : 0L;
+            retryAfter = fresh ? 0L : now + RETRY_BACKOFF_MS;
+        }
+
+        void failed() {
+            retryAfter = System.currentTimeMillis() + RETRY_BACKOFF_MS;
+        }
+    }
+
+    private static final class ChannelState {
+        final ProviderState sevenTv = new ProviderState();
+        final ProviderState betterTtv = new ProviderState();
+    }
+
+    private static final class LoadedValue<T> {
+        final T value;
+        final boolean fresh;
+
+        LoadedValue(T value, boolean fresh) {
+            this.value = value;
+            this.fresh = fresh;
+        }
+    }
+
+    private static final class DaemonThreadFactory implements ThreadFactory {
+        private int nextId;
+
+        @Override
+        public synchronized Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "morphe-emote-catalog-" + nextId++);
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+}

--- a/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteImageLoader.java
+++ b/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteImageLoader.java
@@ -1,0 +1,385 @@
+package app.morphe.extension.twitch.emotes;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.ImageDecoder;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.util.LruCache;
+import android.util.Size;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+final class EmoteImageLoader {
+    private static final int MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+    private static final long MAX_DISK_BYTES = 32L * 1024L * 1024L;
+    private static final int MAX_SOURCE_DIMENSION = 8_192;
+    private static final long MAX_SOURCE_PIXELS = 32L * 1024L * 1024L;
+    private static final int MAX_DECODE_DIMENSION = 512;
+    private static final int MIN_DECODE_DIMENSION = 128;
+    private static final long RETRY_BACKOFF_MS = 5L * 60L * 1000L;
+    private static final String USER_AGENT = "HoomanMorpheTwitchEmotes/1.0";
+
+    private final Object diskCacheLock = new Object();
+    private long diskCacheBytes = -1L;
+    private final Set<String> loading = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<String, Long> failedUntil = new ConcurrentHashMap<>();
+    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+            2,
+            2,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(64),
+            new DaemonThreadFactory()
+    );
+    private final Consumer<String> onUpdated;
+    private final LruCache<String, ImageData> memory = new LruCache<>(16 * 1024 * 1024) {
+        @Override
+        protected int sizeOf(String key, ImageData value) {
+            return Math.max(1, value.costBytes);
+        }
+    };
+
+    EmoteImageLoader(Consumer<String> onUpdated) {
+        this.onUpdated = onUpdated;
+    }
+
+    Drawable createDrawable(Resources resources, Emote emote) {
+        ImageData data = memory.get(emote.url);
+        if (data == null) {
+            return null;
+        }
+        if (data.drawableState != null) {
+            return data.drawableState.newDrawable(resources);
+        }
+        return data.bitmap == null ? null : new BitmapDrawable(resources, data.bitmap);
+    }
+
+    void request(Context context, Emote emote, int targetHeight) {
+        Long retryAfter = failedUntil.get(emote.url);
+        if (retryAfter != null && retryAfter > System.currentTimeMillis()) {
+            return;
+        }
+        if (memory.get(emote.url) != null || !loading.add(emote.url)) {
+            return;
+        }
+        Context applicationContext = context.getApplicationContext();
+        int targetDimension = Math.min(
+                MAX_DECODE_DIMENSION,
+                Math.max(MIN_DECODE_DIMENSION, targetHeight * 2)
+        );
+        try {
+            executor.execute(() -> load(applicationContext, emote, targetDimension));
+        } catch (RejectedExecutionException ignored) {
+            loading.remove(emote.url);
+            failedUntil.put(emote.url, System.currentTimeMillis() + RETRY_BACKOFF_MS);
+        }
+    }
+
+    private void load(Context context, Emote emote, int targetDimension) {
+        boolean succeeded = false;
+        try {
+            File directory = new File(context.getCacheDir(), "morphe_emote_images");
+            File cache = new File(directory, sha256(emote.url) + ".bin");
+            byte[] cached = readCache(cache);
+            ImageData data = null;
+            if (cached != null) {
+                try {
+                    data = decode(cached, emote.animated, targetDimension);
+                } catch (Exception ignored) {
+                    deleteCache(cache);
+                }
+            }
+            if (data == null) {
+                byte[] downloaded = download(emote.url);
+                data = decode(downloaded, emote.animated, targetDimension);
+                writeCache(directory, cache, downloaded);
+            }
+            memory.put(emote.url, data);
+            failedUntil.remove(emote.url);
+            succeeded = true;
+        } catch (Exception ignored) {
+            failedUntil.put(emote.url, System.currentTimeMillis() + RETRY_BACKOFF_MS);
+        } finally {
+            loading.remove(emote.url);
+            if (succeeded) {
+                onUpdated.accept(emote.url);
+            }
+        }
+    }
+
+    private static ImageData decode(byte[] bytes, boolean animated, int targetDimension)
+            throws IOException {
+        if (animated && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            Drawable decoded;
+            try {
+                decoded = ImageDecoder.decodeDrawable(
+                        ImageDecoder.createSource(ByteBuffer.wrap(bytes)),
+                        (decoder, info, source) -> configureDecoder(decoder, info, targetDimension)
+                );
+            } catch (IllegalArgumentException failure) {
+                throw new IOException("Invalid animated emote dimensions", failure);
+            }
+            Drawable.ConstantState state = decoded.getConstantState();
+            if (state != null) {
+                int width = Math.max(1, decoded.getIntrinsicWidth());
+                int height = Math.max(1, decoded.getIntrinsicHeight());
+                long estimate = (long) width * height * 4L * 4L;
+                return new ImageData(null, state, saturatedInt(estimate));
+            }
+        }
+
+        Bitmap bitmap = decodeBitmap(bytes, targetDimension);
+        if (bitmap == null) {
+            throw new IOException("Unable to decode emote image");
+        }
+        return new ImageData(bitmap, null, bitmap.getByteCount());
+    }
+
+    private static void configureDecoder(
+            ImageDecoder decoder,
+            ImageDecoder.ImageInfo info,
+            int targetDimension
+    ) {
+        Size size = info.getSize();
+        validateDimensions(size.getWidth(), size.getHeight());
+        int[] target = constrainedSize(size.getWidth(), size.getHeight(), targetDimension);
+        if (target[0] != size.getWidth() || target[1] != size.getHeight()) {
+            decoder.setTargetSize(target[0], target[1]);
+        }
+    }
+
+    private static Bitmap decodeBitmap(byte[] bytes, int targetDimension) throws IOException {
+        BitmapFactory.Options bounds = new BitmapFactory.Options();
+        bounds.inJustDecodeBounds = true;
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.length, bounds);
+        validateDimensions(bounds.outWidth, bounds.outHeight);
+
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inSampleSize = sampleSize(bounds.outWidth, bounds.outHeight, targetDimension);
+        Bitmap decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
+        if (decoded == null) {
+            return null;
+        }
+
+        int[] target = constrainedSize(decoded.getWidth(), decoded.getHeight(), targetDimension);
+        if (target[0] == decoded.getWidth() && target[1] == decoded.getHeight()) {
+            return decoded;
+        }
+        Bitmap scaled = Bitmap.createScaledBitmap(decoded, target[0], target[1], true);
+        if (scaled != decoded) {
+            decoded.recycle();
+        }
+        return scaled;
+    }
+
+    private static void validateDimensions(int width, int height) {
+        if (width <= 0 || height <= 0 || width > MAX_SOURCE_DIMENSION ||
+                height > MAX_SOURCE_DIMENSION || (long) width * height > MAX_SOURCE_PIXELS) {
+            throw new IllegalArgumentException("Emote dimensions exceed safe decode limits");
+        }
+    }
+
+    private static int sampleSize(int width, int height, int targetDimension) {
+        int sample = 1;
+        while (width / (sample * 2) >= targetDimension &&
+                height / (sample * 2) >= targetDimension) {
+            sample *= 2;
+        }
+        return sample;
+    }
+
+    private static int[] constrainedSize(int width, int height, int maxDimension) {
+        int largest = Math.max(width, height);
+        if (largest <= maxDimension) {
+            return new int[]{width, height};
+        }
+        float scale = (float) maxDimension / largest;
+        return new int[]{
+                Math.max(1, Math.round(width * scale)),
+                Math.max(1, Math.round(height * scale))
+        };
+    }
+
+    private static int saturatedInt(long value) {
+        return value >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) value;
+    }
+
+    private byte[] readCache(File cache) {
+        synchronized (diskCacheLock) {
+            if (!cache.isFile()) {
+                return null;
+            }
+            cache.setLastModified(System.currentTimeMillis());
+            try (InputStream input = new FileInputStream(cache)) {
+                return readLimited(input);
+            } catch (IOException ignored) {
+                deleteCacheLocked(cache);
+                return null;
+            }
+        }
+    }
+
+    private void writeCache(File directory, File cache, byte[] bytes) throws IOException {
+        synchronized (diskCacheLock) {
+            if (!directory.isDirectory() && !directory.mkdirs()) {
+                return;
+            }
+            initializeDiskCacheBytes(directory);
+            long oldLength = cache.isFile() ? cache.length() : 0L;
+            File temporary = new File(directory, cache.getName() + ".tmp");
+            try {
+                try (FileOutputStream output = new FileOutputStream(temporary)) {
+                    output.write(bytes);
+                }
+                if (!temporary.renameTo(cache)) {
+                    try (FileOutputStream output = new FileOutputStream(cache)) {
+                        output.write(bytes);
+                    }
+                }
+            } finally {
+                //noinspection ResultOfMethodCallIgnored
+                temporary.delete();
+            }
+            diskCacheBytes = Math.max(0L, diskCacheBytes - oldLength) + cache.length();
+            trimDiskCache(directory);
+        }
+    }
+
+    private void deleteCache(File cache) {
+        synchronized (diskCacheLock) {
+            deleteCacheLocked(cache);
+        }
+    }
+
+    private void deleteCacheLocked(File cache) {
+        long length = cache.length();
+        if (cache.delete() && diskCacheBytes >= 0L) {
+            diskCacheBytes = Math.max(0L, diskCacheBytes - length);
+        }
+    }
+
+    private static byte[] download(String url) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setConnectTimeout(7_000);
+        connection.setReadTimeout(10_000);
+        connection.setRequestProperty("Accept", "image/webp,image/*;q=0.8");
+        connection.setRequestProperty("User-Agent", USER_AGENT);
+        try {
+            int status = connection.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new IOException("HTTP " + status + " for " + url);
+            }
+            try (InputStream input = connection.getInputStream()) {
+                return readLimited(input);
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static byte[] readLimited(InputStream input) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8_192];
+        int total = 0;
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            total += read;
+            if (total > MAX_IMAGE_BYTES) {
+                throw new IOException("Emote image exceeds " + MAX_IMAGE_BYTES + " bytes");
+            }
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private static String sha256(String value) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(value.getBytes(StandardCharsets.UTF_8));
+        StringBuilder result = new StringBuilder(digest.length * 2);
+        for (byte item : digest) {
+            result.append(String.format("%02x", item & 0xff));
+        }
+        return result.toString();
+    }
+
+    private void initializeDiskCacheBytes(File directory) {
+        if (diskCacheBytes >= 0L) {
+            return;
+        }
+        diskCacheBytes = 0L;
+        File[] files = directory.listFiles((file, name) -> name.endsWith(".bin"));
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            diskCacheBytes += file.length();
+        }
+    }
+
+    private void trimDiskCache(File directory) {
+        if (diskCacheBytes <= MAX_DISK_BYTES) {
+            return;
+        }
+        File[] files = directory.listFiles((file, name) -> name.endsWith(".bin"));
+        if (files == null) {
+            return;
+        }
+        Arrays.sort(files, Comparator.comparingLong(File::lastModified));
+        for (File file : files) {
+            long length = file.length();
+            if (file.delete()) {
+                diskCacheBytes = Math.max(0L, diskCacheBytes - length);
+            }
+            if (diskCacheBytes <= MAX_DISK_BYTES) {
+                break;
+            }
+        }
+    }
+
+    private static final class ImageData {
+        final Bitmap bitmap;
+        final Drawable.ConstantState drawableState;
+        final int costBytes;
+
+        ImageData(Bitmap bitmap, Drawable.ConstantState drawableState, int costBytes) {
+            this.bitmap = bitmap;
+            this.drawableState = drawableState;
+            this.costBytes = costBytes;
+        }
+    }
+
+    private static final class DaemonThreadFactory implements ThreadFactory {
+        private int nextId;
+
+        @Override
+        public synchronized Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "morphe-emote-image-" + nextId++);
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+}

--- a/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteSupport.java
+++ b/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteSupport.java
@@ -1,0 +1,284 @@
+package app.morphe.extension.twitch.emotes;
+
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.SpannedString;
+import android.text.style.ReplacementSpan;
+import android.view.View;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+@SuppressWarnings("unused")
+public final class EmoteSupport {
+    private static final Object LOCK = new Object();
+    private static final WeakHashMap<TextView, BoundMessage> BOUND_MESSAGES = new WeakHashMap<>();
+    private static final EmoteCatalog CATALOG = new EmoteCatalog(EmoteSupport::refreshCatalog);
+    private static final EmoteImageLoader IMAGES = new EmoteImageLoader(EmoteSupport::refreshImage);
+    private static final View.OnAttachStateChangeListener VIEW_LIFECYCLE =
+            new View.OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(View view) {
+                    TextView textView = (TextView) view;
+                    BoundMessage message;
+                    synchronized (LOCK) {
+                        message = BOUND_MESSAGES.get(textView);
+                    }
+                    if (message != null) {
+                        scheduleRender(textView, message);
+                    }
+                }
+
+                @Override
+                public void onViewDetachedFromWindow(View view) {
+                    stopAnimations(((TextView) view).getText());
+                }
+            };
+
+    private static volatile String lastRoomId;
+
+    private EmoteSupport() {
+    }
+
+    public static void onChannelChanged(String channelId, String channelName) {
+        String normalized = normalizeChannelId(channelId);
+        if (normalized != null) {
+            lastRoomId = normalized;
+        }
+    }
+
+    public static void bind(TextView textView, String sourceChannelId) {
+        if (textView == null) {
+            return;
+        }
+        CharSequence current = textView.getText();
+        synchronized (LOCK) {
+            BOUND_MESSAGES.remove(textView);
+        }
+        stopAnimations(current);
+        textView.removeOnAttachStateChangeListener(VIEW_LIFECYCLE);
+
+        if (current == null || current.length() == 0) {
+            return;
+        }
+        String channelId = normalizeChannelId(sourceChannelId);
+        if (channelId == null) {
+            // Normal non-shared-chat rows can omit sourceChannelId. Twitch 29.9.1 presents one active
+            // live-chat room, so use the latest connection key only for that missing-field case.
+            channelId = lastRoomId;
+        }
+
+        BoundMessage message = new BoundMessage(SpannedString.valueOf(current), channelId);
+        synchronized (LOCK) {
+            BOUND_MESSAGES.put(textView, message);
+        }
+        textView.addOnAttachStateChangeListener(VIEW_LIFECYCLE);
+        CATALOG.ensureLoaded(textView.getContext(), channelId);
+        render(textView, message);
+    }
+
+    private static void render(TextView textView, BoundMessage message) {
+        synchronized (LOCK) {
+            if (BOUND_MESSAGES.get(textView) != message) {
+                return;
+            }
+        }
+        if (!textView.isAttachedToWindow()) {
+            return;
+        }
+        stopAnimations(textView.getText());
+
+        SpannedString original = message.original;
+        ReplacementSpan[] existingSpans = original.getSpans(
+                0,
+                original.length(),
+                ReplacementSpan.class
+        );
+        SpannableStringBuilder builder = null;
+        Set<String> pendingImages = null;
+        Map<String, Emote> missingImages = null;
+        int length = original.length();
+        int index = 0;
+        while (index < length) {
+            while (index < length && isSeparator(original.charAt(index))) {
+                index++;
+            }
+            int start = index;
+            while (index < length && !isSeparator(original.charAt(index))) {
+                index++;
+            }
+            int end = index;
+            if (start == end || hasReplacementSpan(original, existingSpans, start, end)) {
+                continue;
+            }
+
+            String token = original.subSequence(start, end).toString();
+            Emote emote = CATALOG.find(message.channelId, token);
+            if (emote == null) {
+                continue;
+            }
+            android.graphics.drawable.Drawable drawable =
+                    IMAGES.createDrawable(textView.getResources(), emote);
+            if (drawable == null) {
+                if (pendingImages == null) {
+                    pendingImages = new HashSet<>();
+                    missingImages = new LinkedHashMap<>();
+                }
+                pendingImages.add(emote.url);
+                missingImages.put(emote.url, emote);
+                continue;
+            }
+
+            if (builder == null) {
+                builder = new SpannableStringBuilder(original);
+            }
+            builder.setSpan(
+                    new CenteredImageSpan(textView, drawable),
+                    start,
+                    end,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            );
+        }
+
+        message.pendingImages = pendingImages == null
+                ? Collections.emptySet()
+                : Collections.unmodifiableSet(pendingImages);
+
+        // Publish pendingImages before enqueueing work. A disk-cache decode can complete immediately on
+        // a worker, and its callback must already be able to find this row as a waiter.
+        if (missingImages != null) {
+            for (Emote emote : missingImages.values()) {
+                IMAGES.request(
+                        textView.getContext(),
+                        emote,
+                        Math.max(1, Math.round(textView.getTextSize() * 1.25f))
+                );
+            }
+        }
+
+        if (builder != null) {
+            textView.setText(new SpannedString(builder), TextView.BufferType.SPANNABLE);
+        } else if (textView.getText() != message.original) {
+            textView.setText(message.original, TextView.BufferType.SPANNABLE);
+        }
+    }
+
+    private static boolean hasReplacementSpan(
+            Spanned text,
+            ReplacementSpan[] spans,
+            int start,
+            int end
+    ) {
+        for (ReplacementSpan span : spans) {
+            if (text.getSpanStart(span) < end && text.getSpanEnd(span) > start) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isSeparator(char value) {
+        return Character.isWhitespace(value) || (value >= '⁦' && value <= '⁩');
+    }
+
+    private static String normalizeChannelId(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty() || trimmed.length() > 20) {
+            return null;
+        }
+        for (int index = 0; index < trimmed.length(); index++) {
+            if (!Character.isDigit(trimmed.charAt(index))) {
+                return null;
+            }
+        }
+        return trimmed;
+    }
+
+    private static void refreshImage(String url) {
+        List<Map.Entry<TextView, BoundMessage>> snapshot = boundMessages();
+        for (Map.Entry<TextView, BoundMessage> entry : snapshot) {
+            TextView textView = entry.getKey();
+            BoundMessage message = entry.getValue();
+            if (textView != null && message != null && message.pendingImages.contains(url)) {
+                scheduleRender(textView, message);
+            }
+        }
+    }
+
+    private static void refreshCatalog(String channelId) {
+        List<Map.Entry<TextView, BoundMessage>> snapshot = boundMessages();
+        for (Map.Entry<TextView, BoundMessage> entry : snapshot) {
+            TextView textView = entry.getKey();
+            BoundMessage message = entry.getValue();
+            if (textView == null || message == null) {
+                continue;
+            }
+            if (channelId == null || channelId.equals(message.channelId)) {
+                scheduleRender(textView, message);
+            }
+        }
+    }
+
+    private static List<Map.Entry<TextView, BoundMessage>> boundMessages() {
+        synchronized (LOCK) {
+            return new ArrayList<>(BOUND_MESSAGES.entrySet());
+        }
+    }
+
+    private static void scheduleRender(TextView textView, BoundMessage message) {
+        synchronized (LOCK) {
+            if (BOUND_MESSAGES.get(textView) != message || message.refreshPosted) {
+                return;
+            }
+            message.refreshPosted = true;
+        }
+        boolean posted = textView.post(() -> {
+            synchronized (LOCK) {
+                message.refreshPosted = false;
+                if (BOUND_MESSAGES.get(textView) != message) {
+                    return;
+                }
+            }
+            render(textView, message);
+        });
+        if (!posted) {
+            synchronized (LOCK) {
+                message.refreshPosted = false;
+            }
+        }
+    }
+
+    private static void stopAnimations(CharSequence text) {
+        if (!(text instanceof Spanned)) {
+            return;
+        }
+        Spanned spanned = (Spanned) text;
+        for (CenteredImageSpan span :
+                spanned.getSpans(0, spanned.length(), CenteredImageSpan.class)) {
+            span.stop();
+        }
+    }
+
+    private static final class BoundMessage {
+        final SpannedString original;
+        final String channelId;
+        volatile Set<String> pendingImages = Collections.emptySet();
+        boolean refreshPosted;
+
+        BoundMessage(SpannedString original, String channelId) {
+            this.original = original;
+            this.channelId = channelId;
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,10 @@ morphe-patcher = "1.5.2"
 #noinspection GradleDependency
 smali = "d92701d947"
 gson = "2.14.0"
+agp = "9.1.0"
 
 [libraries]
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+
+[plugins]
+android-library = { id = "com.android.library" }

--- a/patches/src/main/kotlin/hooman/morphe/patches/batteryguru/pro/UnlockProPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/batteryguru/pro/UnlockProPatch.kt
@@ -24,6 +24,7 @@ val unlockProPatch = bytecodePatch(
             targets = listOf(
                 AppTarget("2.4.8.1"),
                 AppTarget("2.5.0.2-beta1"),
+                AppTarget("2.5.0.6"),
             ),
         ),
     )

--- a/patches/src/main/kotlin/hooman/morphe/patches/cronometer/gold/UnlockGoldPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/cronometer/gold/UnlockGoldPatch.kt
@@ -6,10 +6,10 @@ import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.rawResourcePatch
 
 // Cronometer is Flutter: logic is AOT-compiled into libapp.so, so there's nothing in the DEX to
-// fingerprint. Gold is gated on one cached override (Blutter's field_63) on the User singleton, set
+// fingerprint. Gold is gated on one cached override (Blutter's field_67) on the User singleton, set
 // from the account payload. NOP-ing the tbnz in its setter makes the bool always store true, which
 // unlocks every Gold gate at once. Offsets shift between releases, so match a byte signature
-// anchored on the field_63 store and refuse to patch if it isn't uniquely present.
+// anchored on the field_67 store and refuse to patch if it isn't uniquely present.
 @Suppress("unused")
 val unlockGoldPatch = rawResourcePatch(
     name = "Unlock Gold",
@@ -22,7 +22,7 @@ val unlockGoldPatch = rawResourcePatch(
             name = "Cronometer",
             packageName = "com.cronometer.android.gold",
             appIconColor = 0xF26B21,
-            targets = listOf(AppTarget("4.56.0")),
+            targets = listOf(AppTarget("4.57.4")),
         ),
     )
 
@@ -40,7 +40,7 @@ val unlockGoldPatch = rawResourcePatch(
         }
 
         // tbnz w0,#4,+0xc | add x2,NULL,#0x20 (true) | b +8 | add x2,NULL,#0x30 (false)
-        // | ldur x0,[fp,#-0x18] | ldur x1,[fp,#-8] | stur w2,[x0,#0x63]  (field_63 store)
+        // | ldur x0,[fp,#-0x18] | ldur x1,[fp,#-8] | stur w2,[x0,#0x67]  (field_67 store)
         val signature = intArrayOf(
             0x60, 0x00, 0x20, 0x37, // tbnz w0, #4, +0xc   <- patched to NOP
             0xC2, 0x82, 0x00, 0x91, // add  x2, NULL, #0x20  (true)
@@ -48,14 +48,14 @@ val unlockGoldPatch = rawResourcePatch(
             0xC2, 0xC2, 0x00, 0x91, // add  x2, NULL, #0x30  (false)
             0xA0, 0x83, 0x5E, 0xF8, // ldur x0, [fp, #-0x18]
             0xA1, 0x83, 0x5F, 0xF8, // ldur x1, [fp, #-8]
-            0x02, 0x30, 0x06, 0xB8, // stur w2, [x0, #0x63]  (User.field_63 = gold override)
+            0x02, 0x70, 0x06, 0xB8, // stur w2, [x0, #0x67]  (User.field_67 = gold override)
         ).map { it.toByte() }.toByteArray()
 
         val bytes = lib.readBytes()
         val match = bytes.findUnique(signature)
             ?: throw PatchException(
                 "Gold-override signature not found in $libPath. This patch targets " +
-                    "Cronometer 4.56.0 (arm64); the AOT layout likely changed in a newer " +
+                    "Cronometer 4.57.4 (arm64); the AOT layout likely changed in a newer " +
                     "build and the signature must be re-derived.",
             )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/ads/RemoveAdsPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/ads/RemoveAdsPatch.kt
@@ -23,7 +23,7 @@ val removeAdsPatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 
@@ -64,7 +64,7 @@ val removeAdsPatch = bytecodePatch(
         // extend Post), so an instance-of Post test alone misses it and the promo slips through.
         // Every item runs through the timeline-object factory nf0.c0.b(); returning null there drops it
         // before the feed builder collects it. Drop any BlazedPost outright, and drop a Post when either
-        // blaze flag is set (Post.p1()=getIsBlazed, I1()=getIsTumblrSponsoredPost, both R8-renamed),
+        // blaze flag is set (Post.q1()=getIsBlazed, K1()=getIsTumblrSponsoredPost, both R8-renamed),
         // else fall through to the original factory.
         val factory = TimelineObjectFactoryFingerprint.method
         factory.addInstructionsWithLabels(
@@ -78,9 +78,9 @@ val removeAdsPatch = bytecodePatch(
                 instance-of v1, v0, Lcom/tumblr/rumblr/model/post/Post;
                 if-eqz v1, :original
                 check-cast v0, Lcom/tumblr/rumblr/model/post/Post;
-                invoke-virtual {v0}, Lcom/tumblr/rumblr/model/post/Post;->p1()Z
+                invoke-virtual {v0}, Lcom/tumblr/rumblr/model/post/Post;->q1()Z
                 move-result v1
-                invoke-virtual {v0}, Lcom/tumblr/rumblr/model/post/Post;->I1()Ljava/lang/Boolean;
+                invoke-virtual {v0}, Lcom/tumblr/rumblr/model/post/Post;->K1()Ljava/lang/Boolean;
                 move-result-object v0
                 sget-object v2, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
                 invoke-virtual {v2, v0}, Ljava/lang/Boolean;->equals(Ljava/lang/Object;)Z

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/adfree/DisableAdFreeBannerPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/adfree/DisableAdFreeBannerPatch.kt
@@ -18,7 +18,7 @@ val disableAdFreeBannerPatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/inappupdate/DisableInAppUpdatePatch.kt
@@ -18,7 +18,7 @@ val disableInAppUpdatePatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/notifications/DisableBlogNotificationReminderPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/notifications/DisableBlogNotificationReminderPatch.kt
@@ -16,7 +16,7 @@ val disableBlogNotificationReminderPatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/popups/DisableGiftMessagePopupPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/popups/DisableGiftMessagePopupPatch.kt
@@ -16,7 +16,7 @@ val disableGiftMessagePopupPatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/screenshot/DisableScreenshotSharePatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/screenshot/DisableScreenshotSharePatch.kt
@@ -1,0 +1,32 @@
+package hooman.morphe.patches.tumblr.annoyances.screenshot
+
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.bytecodePatch
+import hooman.morphe.patches.tumblr.featureflags.addFeatureFlagOverride
+import hooman.morphe.patches.tumblr.featureflags.overrideFeatureFlagsPatch
+
+@Suppress("unused")
+val disableScreenshotSharePatch = bytecodePatch(
+    name = "Disable screenshot sharing",
+    description = "Stops the share sheet that pops up when you take a screenshot in the app.",
+) {
+    dependsOn(overrideFeatureFlagsPatch)
+
+    compatibleWith(
+        Compatibility(
+            name = "Tumblr",
+            packageName = "com.tumblr",
+            appIconColor = 0x001935,
+            targets = listOf(AppTarget("45.8.0.110")),
+        ),
+    )
+
+    execute {
+        // SCREENSHOT_INTERCEPTION ("Show share sheet when user takes a screenshot"). The flag is read
+        // both when the screenshot detectors are registered and again inside the on-capture listener
+        // before the share sheet is shown, so forcing it false suppresses the popup for both the API 34+
+        // ScreenCaptureCallback path and the MediaStore observer path.
+        addFeatureFlagOverride("screenshotInterception", "false")
+    }
+}

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/tv/DisableTumblrTvPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/annoyances/tv/DisableTumblrTvPatch.kt
@@ -18,7 +18,7 @@ val disableTumblrTvPatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/featureflags/OverrideFeatureFlagsPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/featureflags/OverrideFeatureFlagsPatch.kt
@@ -37,7 +37,7 @@ val overrideFeatureFlagsPatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/premium/EnablePremiumUiPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/premium/EnablePremiumUiPatch.kt
@@ -23,7 +23,7 @@ val enablePremiumUiPatch = bytecodePatch(
             name = "Tumblr",
             packageName = "com.tumblr",
             appIconColor = 0x001935,
-            targets = listOf(AppTarget("45.0.0.109")),
+            targets = listOf(AppTarget("45.8.0.110")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/ads/BlockLiveAdsPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/ads/BlockLiveAdsPatch.kt
@@ -18,7 +18,7 @@ val blockLiveAdsPatch = bytecodePatch(
             name = "Twitch",
             packageName = "tv.twitch.android.app",
             appIconColor = 0x9147FF,
-            targets = listOf(AppTarget("29.9.1")),
+            targets = listOf(AppTarget("30.7.2")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/ads/DisplayAdsFingerprints.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/ads/DisplayAdsFingerprints.kt
@@ -17,6 +17,6 @@ object DisplayAdResponseParserFingerprint : Fingerprint(
     ),
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     name = "a",
-    returnType = "Lnq;",
+    returnType = "Ldq;",
     parameters = listOf("Lretrofit2/adapter/rxjava2/Result;", "Z"),
 )

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/ads/HideDisplayAdsPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/ads/HideDisplayAdsPatch.kt
@@ -16,19 +16,19 @@ val hideDisplayAdsPatch = bytecodePatch(
             name = "Twitch",
             packageName = "tv.twitch.android.app",
             appIconColor = 0x9147FF,
-            targets = listOf(AppTarget("29.9.1")),
+            targets = listOf(AppTarget("30.7.2")),
         ),
     )
 
     execute {
-        // Return the no-ad singleton (Lgq; = nq.NoAd in this build) from the response parser so every
+        // Return the no-ad singleton (Lwp; = dq.NoAd in this build) from the response parser so every
         // display/banner/in-feed unit resolves to "nothing to show". The 204 branch already returns
-        // this exact value, so it's a path the downstream code handles cleanly. gq is a sibling of the
+        // this exact value, so it's a path the downstream code handles cleanly. wp is a sibling of the
         // matched class and version-pinned along with it.
         DisplayAdResponseParserFingerprint.method.addInstructions(
             0,
             """
-                sget-object v0, Lgq;->a:Lgq;
+                sget-object v0, Lwp;->a:Lwp;
                 return-object v0
             """,
         )

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/chat/AutoClaimChannelPointsPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/chat/AutoClaimChannelPointsPatch.kt
@@ -18,14 +18,14 @@ val autoClaimChannelPointsPatch = bytecodePatch(
             name = "Twitch",
             packageName = "tv.twitch.android.app",
             appIconColor = 0x9147FF,
-            targets = listOf(AppTarget("29.9.1")),
+            targets = listOf(AppTarget("30.7.2")),
         ),
     )
 
     execute {
         // The state provider rebuilds the button's view state on every update. When the incoming state
         // (p1) carries an active claim (field d), a bonus is waiting. Fire the claim through the data
-        // provider it already holds (field m, sk8.H(claimId, ChatModeMetadata)) before building the
+        // provider it already holds (field m, ir8.H(claimId, ChatModeMetadata)) before building the
         // state, passing the claim id (ActiveClaimModel.a) and null metadata. A null claim means no
         // bonus is up, so we skip. Re-claiming a spent bonus is a harmless server no-op, so this is safe
         // even though the method runs on every state update.
@@ -33,12 +33,12 @@ val autoClaimChannelPointsPatch = bytecodePatch(
         method.addInstructionsWithLabels(
             0,
             """
-                iget-object v0, p1, Lxg8;->d:Lnb;
+                iget-object v0, p1, Lmn8;->d:Lkb;
                 if-eqz v0, :skip
-                iget-object v1, v0, Lnb;->a:Ljava/lang/String;
-                iget-object v2, p0, Lkh8;->m:Lsk8;
+                iget-object v1, v0, Lkb;->a:Ljava/lang/String;
+                iget-object v2, p0, Lzn8;->m:Lir8;
                 const/4 v3, 0x0
-                invoke-interface {v2, v1, v3}, Lsk8;->H(Ljava/lang/String;Ltv/twitch/android/shared/one/chat/pub/ChatModeMetadata;)V
+                invoke-interface {v2, v1, v3}, Lir8;->H(Ljava/lang/String;Ltv/twitch/android/shared/one/chat/pub/ChatModeMetadata;)V
             """,
             ExternalLabel("skip", method.getInstruction(0)),
         )

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/chat/ChatFingerprints.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/chat/ChatFingerprints.kt
@@ -23,18 +23,18 @@ object DeletedMessageSpanCtorFingerprint : Fingerprint(
     },
 )
 
-// The community-points button state provider (kh8 = CommunityPointsButtonStateProvider). U2(state)
+// The community-points button state provider (zn8 = CommunityPointsButtonStateProvider). V2(state)
 // rebuilds the button's view state on every update; when the incoming state carries an active claim
 // (field d, an ActiveClaimModel) a bonus is waiting to be claimed. The provider holds the data
-// provider that performs the claim (field m, type sk8, exposing H(claimId, ChatModeMetadata)). R8
+// provider that performs the claim (field m, type ir8, exposing H(claimId, ChatModeMetadata)). R8
 // renames the class, so pin it by the MVP state-class name it keeps in a method signature string, plus
-// the U2(state)->viewState shape.
+// the V2(state)->viewState shape.
 object CommunityPointsStateProviderFingerprint : Fingerprint(
     classFingerprint = Fingerprint(
         strings = listOf("CommunityPointsButtonStateProvider\$State"),
     ),
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
-    name = "U2",
-    returnType = "Lvg8;",
-    parameters = listOf("Lxg8;"),
+    name = "V2",
+    returnType = "Lkn8;",
+    parameters = listOf("Lmn8;"),
 )

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/chat/ShowDeletedMessagesPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/chat/ShowDeletedMessagesPatch.kt
@@ -17,7 +17,7 @@ val showDeletedMessagesPatch = bytecodePatch(
             name = "Twitch",
             packageName = "tv.twitch.android.app",
             appIconColor = 0x9147FF,
-            targets = listOf(AppTarget("29.9.1")),
+            targets = listOf(AppTarget("30.7.2")),
         ),
     )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/emotes/Fingerprints.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/emotes/Fingerprints.kt
@@ -1,0 +1,29 @@
+package hooman.morphe.patches.twitch.emotes
+
+import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal const val CHANNEL_CONNECTION_KEY =
+    "Ltv/twitch/android/shared/chat/pub/messages/data/ChannelChatConnectionKey;"
+internal const val CHAT_TEXT_SETTER =
+    "Landroid/widget/TextView;->setText(Ljava/lang/CharSequence;Landroid/widget/TextView\$BufferType;)V"
+
+// Twitch keeps this Parcelable model unobfuscated because it crosses the public chat connection API.
+// Its constructor receives the numeric broadcaster ID required by both 7TV and BTTV.
+internal object ChannelConnectionConstructorFingerprint : Fingerprint(
+    classFingerprint = Fingerprint(
+        custom = { _, classDef -> classDef.type == CHANNEL_CONNECTION_KEY },
+    ),
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;", "Ljava/lang/String;"),
+)
+
+// MessageRecyclerItem is R8-renamed, but its data-class toString labels survive. sourceChannelId is
+// also used as the per-row fallback when Shared Chat shows messages from another broadcaster.
+internal object MessageRecyclerItemClassFingerprint : Fingerprint(
+    strings = listOf(
+        "MessageRecyclerItem(messageId=",
+        ", sourceChannelId=",
+    ),
+)

--- a/patches/src/main/kotlin/hooman/morphe/patches/twitch/emotes/ThirdPartyEmotesPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/twitch/emotes/ThirdPartyEmotesPatch.kt
@@ -1,0 +1,147 @@
+package hooman.morphe.patches.twitch.emotes
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+
+private const val EXTENSION = "Lapp/morphe/extension/twitch/emotes/EmoteSupport;"
+
+@Suppress("unused")
+val thirdPartyEmotesPatch = bytecodePatch(
+    name = "7TV and BTTV emotes",
+    description = "Renders global and current-channel 7TV and BTTV emotes in incoming live chat. " +
+        "Type an emote code normally to send it; this patch does not add a picker or provider login.",
+) {
+    compatibleWith(
+        Compatibility(
+            name = "Twitch",
+            packageName = "tv.twitch.android.app",
+            appIconColor = 0x9147FF,
+            targets = listOf(AppTarget("30.7.2")),
+        ),
+    )
+
+    extendWith("extensions/twitch.mpe")
+
+    execute {
+        val channelConstructor = ChannelConnectionConstructorFingerprint.method
+        val channelInstructions = channelConstructor.instructions
+        if (channelInstructions.lastOrNull()?.opcode != Opcode.RETURN_VOID) {
+            throw PatchException("Twitch emotes: channel connection constructor no longer ends in return-void.")
+        }
+        channelConstructor.addInstructions(
+            channelInstructions.lastIndex,
+            "invoke-static { p1, p2 }, $EXTENSION->onChannelChanged(Ljava/lang/String;Ljava/lang/String;)V",
+        )
+
+        val messageClass = MessageRecyclerItemClassFingerprint.classDef
+        val toStringMethod = messageClass.methods.singleOrNull { method ->
+            method.name == "toString" &&
+                method.returnType == "Ljava/lang/String;" &&
+                method.parameterTypes.isEmpty()
+        } ?: throw PatchException("Twitch emotes: MessageRecyclerItem.toString was not found uniquely.")
+        val toStringInstructions = toStringMethod.implementation?.instructions
+            ?: throw PatchException("Twitch emotes: MessageRecyclerItem.toString has no implementation.")
+        val sourceMarkerIndex = toStringInstructions.indexOfFirst { instruction ->
+            ((instruction as? ReferenceInstruction)?.reference as? StringReference)?.string ==
+                ", sourceChannelId="
+        }
+        if (sourceMarkerIndex < 0) {
+            throw PatchException("Twitch emotes: sourceChannelId marker was not found.")
+        }
+        val nextLabelIndex = toStringInstructions
+            .drop(sourceMarkerIndex + 1)
+            .indexOfFirst { instruction ->
+                (instruction as? ReferenceInstruction)?.reference is StringReference
+            }
+            .let { relativeIndex ->
+                if (relativeIndex < 0) toStringInstructions.size
+                else sourceMarkerIndex + 1 + relativeIndex
+            }
+        val sourceFields = toStringInstructions
+            .subList(sourceMarkerIndex + 1, nextLabelIndex)
+            .mapNotNull { instruction ->
+                (instruction as? ReferenceInstruction)?.reference as? FieldReference
+            }
+            .filter { field ->
+                field.definingClass == messageClass.type && field.type == "Ljava/lang/String;"
+            }
+            .distinctBy { it.toString() }
+        val sourceChannelField = sourceFields.singleOrNull()
+            ?: throw PatchException(
+                "Twitch emotes: expected one String field after sourceChannelId, found " +
+                    sourceFields.size + ".",
+            )
+
+        fun isChatBindMethod(method: Method): Boolean {
+            val instructions = method.implementation?.instructions ?: return false
+            return method.returnType == "V" &&
+                method.parameterTypes.size == 2 &&
+                method.parameterTypes[0].toString() == messageClass.type &&
+                method.parameterTypes[1].toString() == "Z" &&
+                instructions.count { instruction ->
+                    val reference =
+                        (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                    reference?.toString() == CHAT_TEXT_SETTER
+                } == 1
+        }
+
+        val rowClassDef = classDefByStrings("glideTarget")
+            .singleOrNull { classDef ->
+                val hasContextPin = classDef.methods.any { method ->
+                    method.implementation?.instructions?.any { instruction ->
+                        ((instruction as? ReferenceInstruction)?.reference as? StringReference)?.string ==
+                            "getApplicationContext(...)"
+                    } == true
+                }
+                hasContextPin && classDef.methods.any(::isChatBindMethod)
+            } ?: throw PatchException(
+                "Twitch emotes: chat row holder pinned by its Glide cleanup was not found uniquely.",
+            )
+        val rowClass = mutableClassDefBy(rowClassDef)
+        val bindMethod = rowClass.methods.singleOrNull(::isChatBindMethod)
+            ?: throw PatchException("Twitch emotes: chat row bind method was not found uniquely.")
+        val implementation = bindMethod.implementation
+            ?: throw PatchException("Twitch emotes: chat row binder has no implementation.")
+        val textCalls = bindMethod.instructions.withIndex().filter { (_, instruction) ->
+            val reference = (instruction as? ReferenceInstruction)?.reference as? MethodReference
+            reference?.toString() == CHAT_TEXT_SETTER
+        }.toList()
+        if (textCalls.size != 1) {
+            throw PatchException(
+                "Twitch emotes: expected one chat TextView.setText call, found ${textCalls.size}.",
+            )
+        }
+        val textCall = textCalls.single()
+        val registers = textCall.value as? FiveRegisterInstruction
+            ?: throw PatchException("Twitch emotes: chat TextView.setText is not a 35c invoke.")
+        if (registers.registerCount != 3 || implementation.registerCount != 20 ||
+            registers.registerC != 3
+        ) {
+            throw PatchException(
+                "Twitch emotes: chat row register layout changed; refusing to reuse scratch v4.",
+            )
+        }
+
+        // v4 is dead after this setText and is overwritten before its next read in 29.9.1. p1 is above
+        // the four-bit iget register range, so first move the row model down, then load its source ID.
+        bindMethod.addInstructions(
+            textCall.index + 1,
+            """
+                move-object/from16 v4, p1
+                iget-object v4, v4, $sourceChannelField
+                invoke-static { v${registers.registerC}, v4 }, $EXTENSION->bind(Landroid/widget/TextView;Ljava/lang/String;)V
+            """,
+        )
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,3 +19,10 @@ pluginManagement {
 plugins {
     id("app.morphe.patches") version "1.3.2"
 }
+
+settings {
+    extensions {
+        defaultNamespace = "app.morphe.extension"
+        proguardFiles(rootProject.projectDir.resolve("extensions/proguard-rules.pro").toString())
+    }
+}


### PR DESCRIPTION
Updates several patches to the latest app versions and adds two new patches.

New app version support:
- Battery Guru 2.5.0.6
- Cronometer 4.57.4 (re-derived the Flutter gold-override signature; field offset moved 0x63 to 0x67)
- Tumblr 45.8.0.110 (also fixed Remove ads: the blaze getters drifted, one silently repurposed, so it was dropping the wrong posts)
- Twitch 30.7.2 (re-derived Hide display ads and Auto claim channel points; verified the other three)

New patches:
- Tumblr: Disable screenshot sharing (request #58) - forces the screenshotInterception flag off so the share sheet no longer pops up on screenshot
- Twitch: 7TV and BTTV emotes (requests #79, #175) - first patch to ship a Morphe Android extension

All patches build and apply cleanly against the target versions.