### PR TITLE
feat: add Google Phone call recording and AutoZen patches

### DIFF
--- a/patches/src/main/kotlin/hooman/morphe/patches/autozen/analytics/DisableAnalyticsPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/autozen/analytics/DisableAnalyticsPatch.kt
@@ -1,0 +1,52 @@
+package hooman.morphe.patches.autozen.analytics
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import hooman.morphe.patches.autozen.checks.disableChecksPatch
+
+@Suppress("unused")
+val disableAnalyticsPatch = bytecodePatch(
+    name = "Disable analytics",
+    description = "Stops AutoZen from sending its own usage analytics. All app events, screen views, " +
+        "and user properties flow through one tracker list; this empties it so nothing is reported.",
+) {
+    dependsOn(disableChecksPatch)
+
+    compatibleWith(
+        Compatibility(
+            name = "AutoZen",
+            packageName = "com.zenthek.autozen",
+            appIconColor = 0x1B1B1B,
+            targets = listOf(AppTarget("8.0.10")),
+        ),
+    )
+
+    execute {
+        // AppTrackerImpl fans every trackEvent/trackScreen/setUserProperty out over getListOfTrackers()
+        // (Firebase + Sentry). Return an empty list so the facade has nothing to forward to. App packages
+        // are not obfuscated, so pin by descriptor.
+        val tracker = mutableClassDefByOrNull(
+            "Lcom/zenthek/autozen/tracking/AppTrackerImpl;",
+        ) ?: throw PatchException(
+            "AutoZen: AppTrackerImpl not found. The analytics facade changed.",
+        )
+        val listOfTrackers = tracker.methods.firstOrNull { method ->
+            method.name == "getListOfTrackers" &&
+                method.returnType == "Ljava/util/List;" &&
+                method.parameterTypes.isEmpty()
+        } ?: throw PatchException(
+            "AutoZen: AppTrackerImpl.getListOfTrackers() not found. Re-derive.",
+        )
+        listOfTrackers.addInstructions(
+            0,
+            """
+                invoke-static {}, Ljava/util/Collections;->emptyList()Ljava/util/List;
+                move-result-object v0
+                return-object v0
+            """,
+        )
+    }
+}

--- a/patches/src/main/kotlin/hooman/morphe/patches/autozen/checks/DisableChecksPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/autozen/checks/DisableChecksPatch.kt
@@ -1,0 +1,63 @@
+package hooman.morphe.patches.autozen.checks
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+
+// Internal (no name): applied automatically as a dependency of the AutoZen patches. A re-signed
+// sideload trips two independent boot blocks, both in DEX (there is no libpairipcore.so, so no native
+// wall). This neutralizes both so the patched app can launch.
+@Suppress("unused")
+val disableChecksPatch = bytecodePatch(
+    description = "Removes AutoZen's two re-sign boot blocks: the PairIP Google Play license check and " +
+        "the Firebase App Check \"installed from Play\" check. Applied automatically with the AutoZen " +
+        "patches so the patched app can open.",
+) {
+    compatibleWith(
+        Compatibility(
+            name = "AutoZen",
+            packageName = "com.zenthek.autozen",
+            appIconColor = 0x1B1B1B,
+            targets = listOf(AppTarget("8.0.10")),
+        ),
+    )
+
+    execute {
+        // Block 1 - PairIP Play licensing. Application.attachBaseContext calls
+        // LicenseClient.checkLicense(context); on a sideloaded install the LVL response is NOT_LICENSED
+        // and it launches the paywall. PairIP keeps these names unobfuscated; pin by the service action.
+        val licenseClass = classDefByStrings("com.android.vending.licensing.ILicensingService")
+            .firstOrNull()
+            ?: throw PatchException(
+                "AutoZen: PairIP LicenseClient (ILicensingService) not found. The license layout changed.",
+            )
+        mutableClassDefBy(licenseClass).methods.firstOrNull { method ->
+            method.name == "checkLicense" &&
+                method.returnType == "V" &&
+                method.parameterTypes == listOf("Landroid/content/Context;")
+        }?.addInstructions(0, "return-void")
+            ?: throw PatchException("AutoZen: PairIP LicenseClient.checkLicense(Context) not found.")
+
+        // Block 2 - Firebase App Check installer gate. SplashScreenViewModel shows AppCheckFailedActivity
+        // when the installer is not an allowed store; IsValidInstallerUseCase.execute() decides that.
+        // The app packages are not obfuscated, so pin by descriptor and force it true.
+        val installerCheck = mutableClassDefByOrNull(
+            "Lcom/zenthek/domain/playstore/IsValidInstallerUseCase;",
+        ) ?: throw PatchException(
+            "AutoZen: IsValidInstallerUseCase not found. The install-source check moved.",
+        )
+        installerCheck.methods.firstOrNull { method ->
+            method.name == "execute" &&
+                method.returnType == "Z" &&
+                method.parameterTypes.isEmpty()
+        }?.addInstructions(
+            0,
+            """
+                const/4 v0, 0x1
+                return v0
+            """,
+        ) ?: throw PatchException("AutoZen: IsValidInstallerUseCase.execute()Z not found.")
+    }
+}

--- a/patches/src/main/kotlin/hooman/morphe/patches/autozen/premium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/autozen/premium/UnlockPremiumPatch.kt
@@ -1,0 +1,57 @@
+package hooman.morphe.patches.autozen.premium
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import hooman.morphe.patches.autozen.checks.disableChecksPatch
+
+@Suppress("unused")
+val unlockPremiumPatch = bytecodePatch(
+    name = "Unlock premium",
+    description = "Unlocks AutoZen's premium features (all tiers and lifetime), which also removes the " +
+        "ads since the ad manager only shows ads to non-premium users. Anything AutoZen verifies on its " +
+        "own servers is not affected.",
+) {
+    dependsOn(disableChecksPatch)
+
+    compatibleWith(
+        Compatibility(
+            name = "AutoZen",
+            packageName = "com.zenthek.autozen",
+            appIconColor = 0x1B1B1B,
+            targets = listOf(AppTarget("8.0.10")),
+        ),
+    )
+
+    execute {
+        // Every feature gate (28 of them) and the ad manager read entitlement through PremiumManager,
+        // whose sole impl is PremiumManagerImpl. Force its tier booleans true so all features unlock and
+        // AdManagerImpl.shouldDisplayAds()/... short-circuit to false. The app packages are not
+        // obfuscated, so pin by descriptor.
+        val premiumImpl = mutableClassDefByOrNull(
+            "Lcom/zenthek/domain/inappbilling/PremiumManagerImpl;",
+        ) ?: throw PatchException(
+            "AutoZen: PremiumManagerImpl not found. The billing layer changed.",
+        )
+
+        val gates = listOf(
+            "itHasAnyPremium", "isPremium", "isPremiumPlus", "isBasicPremium", "itHasLifeTime",
+        )
+        for (name in gates) {
+            val method = premiumImpl.methods.firstOrNull {
+                it.name == name && it.returnType == "Z" && it.parameterTypes.isEmpty()
+            } ?: throw PatchException(
+                "AutoZen: PremiumManagerImpl.$name()Z not found. Re-derive the premium gates.",
+            )
+            method.addInstructions(
+                0,
+                """
+                    const/4 v0, 0x1
+                    return v0
+                """,
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/hooman/morphe/patches/dialer/callrecording/EnableCallRecordingPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/dialer/callrecording/EnableCallRecordingPatch.kt
@@ -1,0 +1,60 @@
+package hooman.morphe.patches.dialer.callrecording
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val enableCallRecordingPatch = bytecodePatch(
+    name = "Enable call recording",
+    description = "Turns on the built-in call recorder in regions where Google normally hides it. " +
+        "Recordings stay on your phone. Recording calls is regulated in many places, so check what is " +
+        "allowed where you live before using it.",
+) {
+    compatibleWith(
+        Compatibility(
+            name = "Google Phone",
+            packageName = "com.google.android.dialer",
+            appIconColor = 0x1A73E8,
+            targets = listOf(
+                AppTarget("161.0.726587057"),
+                AppTarget("161.0.726587057-downloadable"),
+            ),
+        ),
+    )
+
+    execute {
+        // Google gates the in-call recorder on a client-side country allowlist. The CanRecord helper
+        // resolves that to one boolean the record button reads; force it true so recording is always
+        // offered. The recorder is fully on-device (recordings never leave the phone), so nothing
+        // server-side needs to change. R8 renames the class; the CanRecord class tag is shared with a
+        // sibling, so pin by the log line unique to the country gate, then force its single no-arg
+        // boolean availability method true.
+        val canRecord = classDefByStrings(
+            "Call recording is disabled in the current country",
+        ).singleOrNull()
+            ?: throw PatchException(
+                "Google Phone: CanRecord class not found or ambiguous. The call-recording gate changed.",
+            )
+        val mutableCanRecord = mutableClassDefBy(canRecord)
+
+        val availability = mutableCanRecord.methods.filter { method ->
+            method.returnType == "Z" && method.parameterTypes.isEmpty()
+        }
+        if (availability.size != 1) {
+            throw PatchException(
+                "Google Phone: expected one no-arg boolean availability method on CanRecord, found " +
+                    "${availability.size}. Re-derive.",
+            )
+        }
+        availability.single().addInstructions(
+            0,
+            """
+                const/4 v0, 0x1
+                return v0
+            """,
+        )
+    }
+}


### PR DESCRIPTION
Two new apps.

Google Phone (com.google.android.dialer 161.0.726587057) - discussion #43:
- Enable call recording: forces the client-side country gate (CanRecord) true so the on-device recorder is available everywhere. Recordings stay on the phone. Call screening was investigated and left out - the feature is server-provisioned per region, so a client flag can only show a non-functional toggle.

AutoZen Car Dashboard (com.zenthek.autozen 8.0.10) - discussion #126:
- Unlock premium: forces the PremiumManager tier booleans true, which unlocks all features and removes ads (the ad manager only shows ads to non-premium users).
- Disable analytics: empties the tracker list so no app events are reported.
- Internal bypass (bundled, not user-selectable): no-ops the PairIP Play license check and forces the Firebase App Check installer check to pass, so the re-signed build boots. No native anti-tamper (no libpairipcore.so), so this is a clean DEX bypass.

All patches build and apply cleanly against the target versions.