### PR TITLE
Support latest versions: FolderSync, Cashew, Acrobat, Collectr, Cronometer

### DIFF
--- a/patches/src/main/kotlin/hooman/morphe/patches/acrobat/premium/UnlockProPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/acrobat/premium/UnlockProPatch.kt
@@ -8,6 +8,9 @@ import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patcher.util.smali.ExternalLabel
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Suppress("unused")
 val unlockProPatch = bytecodePatch(
@@ -21,61 +24,116 @@ val unlockProPatch = bytecodePatch(
             name = "Adobe Acrobat",
             packageName = "com.adobe.reader",
             appIconColor = 0xB30B00,
-            targets = listOf(AppTarget("26.5.0.45958")),
+            targets = listOf(AppTarget("26.7.1.47181")),
         ),
     )
 
     execute {
-        // SVServicesAccount is the single entitlement chokepoint, and its names survive R8. Every
-        // feature gate reads it through z0/G0/H0, which short-circuit to false unless E0() (signed
-        // in) is true. Pin the class by descriptor, match each method by shape.
+        // SVServicesAccount is the single entitlement chokepoint, and the class descriptor survives R8.
+        // Every feature gate reads it through a small set of "is entitled" methods keyed by SERVICE_TYPE
+        // or SERVICES_VARIANTS. Pin the class by descriptor; select the gate methods by SHAPE, not name.
         val account = mutableClassDefByOrNull("Lcom/adobe/libs/services/auth/SVServicesAccount;")
             ?: throw PatchException(
                 "Acrobat: SVServicesAccount not found. The services-account package changed.",
             )
 
-        // We grant the on-device entitlements at the TOP of z0/G0/H0, before their own !E0() guard
-        // runs, so the granted types read true even though the account is really signed out. We do
-        // NOT force E0() itself: a globally-spoofed signed-in state with no real Adobe token sends
-        // the app down the authenticated paths it can't finish. The worst is a Play-Billing /
-        // paywall subscription reconcile that never converges and respins a BillingClient about
-        // twice a second for the whole session (the "glitchy" behaviour). Leaving E0() honest keeps
-        // that reconcile on its signed-out branch, which resolves cleanly, while the per-type grants
-        // still unlock the tools.
-
-        // z0(SERVICE_TYPE) backs every feature gate. Grant the on-device Pro types and let the cloud
-        // types fall through to their real value, so the app doesn't offer cloud work it can't finish.
-        // Match the enum constant name, not the ordinal, which R8 can renumber.
+        // R8 renames these gate methods every release, which is what broke the old name-pinned patch on
+        // 26.6.2+ (issue #131). Match by shape instead. We grant the on-device Pro entitlements at the TOP
+        // of each gate, before its own signed-in guard, so the granted types read true even though the
+        // account is really signed out. We do NOT force the signed-in check itself: a globally-spoofed
+        // signed-in state with no real Adobe token sends the app into a Play-Billing reconcile that never
+        // converges and respins a BillingClient about twice a second for the session (the "glitchy"
+        // behaviour). Leaving it honest keeps that reconcile on its signed-out branch while the per-type
+        // grants still unlock the tools. Grant by enum name(), not ordinal, which R8 can renumber.
         val serviceTypeDesc = "Lcom/adobe/libs/services/utils/SVConstants\$SERVICE_TYPE;"
-        val z0 = account.methods.firstOrNull {
-            it.name == "z0" && it.returnType == "Z" && it.parameterTypes == listOf(serviceTypeDesc)
-        }
-            ?: throw PatchException("Acrobat: SVServicesAccount.z0(SERVICE_TYPE)Z not found. The entitlement gate shape changed.")
-        z0.grantForEnumNames(
-            "ACROBATPRO_SERVICE",
-            "ACROBAT_PREMIUM_SERVICE",
-            "EDITPDF_SERVICE",
-            "ORGANIZEPDF_SERVICE",
-            "CROPPDF_SERVICE",
-            "ACROBAT_DC_LITE_SERVICE",
-        )
-
-        // G0/H0(SERVICES_VARIANTS) are the variant-level reads behind the same gates. Same grant.
         val variantDesc = "Lcom/adobe/libs/services/utils/SVConstants\$SERVICES_VARIANTS;"
+
+        // SERVICE_TYPE gates: every public (SERVICE_TYPE)Z method. On 26.7.1 that is the MeterIQ entry
+        // point (which delegates its arg to the private legacy readers) plus one direct reader; granting
+        // at their top short-circuits before the real read, so the private helpers are covered too. Grant
+        // the on-device Pro types and let cloud types fall through so the app can't offer work it can't
+        // finish server-side.
+        val serviceTypeGates = account.methods.filter {
+            it.returnType == "Z" &&
+                it.parameterTypes == listOf(serviceTypeDesc) &&
+                AccessFlags.PUBLIC.isSet(it.accessFlags)
+        }
+        if (serviceTypeGates.isEmpty()) {
+            throw PatchException(
+                "Acrobat: no public (SERVICE_TYPE)Z gate on SVServicesAccount. The entitlement API changed.",
+            )
+        }
+        serviceTypeGates.forEach {
+            it.grantForEnumNames(
+                "ACROBATPRO_SERVICE",
+                "ACROBAT_PREMIUM_SERVICE",
+                "EDITPDF_SERVICE",
+                "ORGANIZEPDF_SERVICE",
+                "CROPPDF_SERVICE",
+                "ACROBAT_DC_LITE_SERVICE",
+            )
+        }
+
+        // SERVICES_VARIANTS gates: public (SERVICES_VARIANTS)Z methods that actually read a subscription
+        // status pref. The "...SubscriptionStatusKey" string literals survive R8 and let us skip the
+        // account-type check (the one SERVICES_VARIANTS method that ignores its arg and reads no pref).
+        val variantGates = account.methods.filter {
+            it.returnType == "Z" &&
+                it.parameterTypes == listOf(variantDesc) &&
+                AccessFlags.PUBLIC.isSet(it.accessFlags) &&
+                it.readsSubscriptionStatusKey()
+        }
+        if (variantGates.isEmpty()) {
+            throw PatchException(
+                "Acrobat: no public (SERVICES_VARIANTS)Z entitlement read on SVServicesAccount. " +
+                    "The variant gate shape changed.",
+            )
+        }
         val proVariants = arrayOf(
             "ACROBAT_PRO_SUBSCRIPTION",
             "ACROBAT_PREMIUM_SUBSCRIPTION",
             "ACROBAT_DC_LITE_SUBSCRIPTION",
         )
-        listOf("G0", "H0").forEach { name ->
-            val method = account.methods.firstOrNull {
-                it.name == name && it.returnType == "Z" && it.parameterTypes == listOf(variantDesc)
-            }
-                ?: throw PatchException("Acrobat: SVServicesAccount.$name(SERVICES_VARIANTS)Z not found. The variant gate shape changed.")
-            method.grantForEnumNames(*proVariants)
-        }
+        variantGates.forEach { it.grantForEnumNames(*proVariants) }
+
+        // The entitlement grant alone does not let the Edit tool START. Edit's PDF engine ships in the
+        // base APK (com.adobe.libs.pdfEditCore / pdfEditUI), but tapping Edit first asks Google Play to
+        // install an on-demand dynamic-feature module (ARDynamicFeature.EDIT, module "PDFEditFontsDF",
+        // label "Fonts For Edit"). On a re-signed sideload Play cannot serve that split, the install
+        // fails, and the launcher aborts with "There was an error in starting Edit. Please try clearing
+        // the cache data of your Play Store application" (string IDS_EDIT_DF_DOWNLOAD_ERROR). The tool
+        // launcher gates on one predicate: a static (Context, ARDynamicFeature)Z that returns true only
+        // when SplitInstallManager.getInstalledModules() already holds every required module -- if false
+        // it runs the download instead of opening the tool. Report EDIT as installed so the launcher
+        // skips the download and opens Edit using the fonts already bundled in base. Only EDIT: the other
+        // modules carry real code the APK does not contain (the OCR engine, Fill and Sign's OpenCV lib),
+        // so faking those would turn a clean "can't download" message into a crash.
+        val featureDesc = "Lcom/adobe/reader/dynamicFeature/ARDynamicFeature;"
+        val dfHelper = classDefByStrings("Feature Available Without Explicit Download").singleOrNull()
+            ?: throw PatchException(
+                "Acrobat: dynamic-feature install helper not found. The DF install check moved.",
+            )
+        val installedCheck = mutableClassDefBy(dfHelper).methods.singleOrNull {
+            it.returnType == "Z" &&
+                it.parameterTypes == listOf("Landroid/content/Context;", featureDesc) &&
+                AccessFlags.STATIC.isSet(it.accessFlags)
+        } ?: throw PatchException(
+            "Acrobat: dynamic-feature install check (Context, ARDynamicFeature)Z not found.",
+        )
+        // Same "return true when the enum arg's name() matches" shape as the entitlement gates: here the
+        // enum arg is the ARDynamicFeature, so name() == "EDIT" forces the module-installed result.
+        installedCheck.grantForEnumNames("EDIT")
     }
 }
+
+// True if the method reads any "...SubscriptionStatusKey" SharedPreferences key. That string literal
+// survives R8 and marks a real entitlement read, so it separates the variant gates from the account-type
+// check (some keys carry a stray leading space in the DEX, hence the trim).
+private fun MutableMethod.readsSubscriptionStatusKey(): Boolean =
+    implementation?.instructions?.any { instruction ->
+        ((instruction as? ReferenceInstruction)?.reference as? StringReference)
+            ?.string?.trim()?.endsWith("SubscriptionStatusKey") == true
+    } == true
 
 // Grant (return true) if the enum parameter's name() matches a granted constant, else fall through
 // to the original body. Name, not ordinal, because R8 renumbers ordinals.

--- a/patches/src/main/kotlin/hooman/morphe/patches/cashew/pro/UnlockProPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/cashew/pro/UnlockProPatch.kt
@@ -7,21 +7,21 @@ import app.morphe.patcher.patch.rawResourcePatch
 
 // Cashew is a Flutter app, so the Pro logic is AOT-compiled into lib/arm64-v8a/libapp.so, not the DEX.
 // Pro is a local flag: a purchase writes appStateSettings["purchaseID"] (null on a free install). The
-// app funnels its upsell gates through one discrete helper, hidePremiumPopup() at 0x842444, which the
+// app funnels its upsell gates through one discrete helper, hidePremiumPopup() at 0x93dde4, which the
 // premium popups (budgets/objectives/past-budgets and ~13 other call sites) read to decide whether to
 // nag or allow the action. It returns true when premiumPopupEnabled is off OR purchaseID is non-null.
 //
-// hidePremiumPopup is a real code object here (bl #0x842444, not inlined), so we hit the function once
+// hidePremiumPopup is a real code object here (bl #0x93dde4, not inlined), so we hit the function once
 // and every caller follows. Near its top:
-//   0x842478: bl   InitLateStaticFieldStub   ; finish loading premiumPopupEnabled
-//   0x84247c: tbnz w0, #4, #0x8424c8         ; if NOT enabled, jump to the "return true" block
+//   0x93de18: bl   InitLateStaticFieldStub   ; finish loading premiumPopupEnabled
+//   0x93de1c: tbnz w0, #4, #0x93de70         ; if NOT enabled, jump to the "return true" block
 //   ...read appStateSettings["purchaseID"], non-null -> return true, else previewDemo check...
-//   0x8424c8: r0 = true ; b #0x842524 (LeaveFrame; ret)
+//   0x93de70: r0 = true ; b #0x93dec4 (LeaveFrame; ret)
 // With Dart true = NULL+0x20 / false = NULL+0x10, tbnz w0,#4 branches when premiumPopupEnabled is
-// false. The overwrite below forces that branch unconditional; the prologue already ran and 0x8424c8
+// false. The overwrite below forces that branch unconditional; the prologue already ran and 0x93de70
 // flows into LeaveFrame/ret, so the frame stays balanced on the function's own return path.
 //
-// Machine-code offsets shift between releases, so this is pinned to the arm64 5.3.4 build (Dart 3.1.3)
+// Machine-code offsets shift between releases, so this is pinned to the arm64 6.6.11 build (Dart 3.12.2)
 // and must be re-derived with Blutter on a new version.
 @Suppress("unused")
 val unlockProPatch = rawResourcePatch(
@@ -36,7 +36,7 @@ val unlockProPatch = rawResourcePatch(
             name = "Cashew",
             packageName = "com.budget.tracker_app",
             appIconColor = 0xF6B858,
-            targets = listOf(AppTarget("5.3.4")),
+            targets = listOf(AppTarget("6.6.11")),
         ),
     )
 
@@ -45,36 +45,36 @@ val unlockProPatch = rawResourcePatch(
         val lib = get(libPath)
         if (!lib.exists()) {
             throw PatchException(
-                "$libPath not found in the APK. This targets the arm64 Cashew 5.3.4 build; if the input " +
+                "$libPath not found in the APK. This targets the arm64 Cashew 6.6.11 build; if the input " +
                     "is a split/xapk bundle, merge it to an arm64 universal with APKEditor m first so " +
                     "the arm64_v8a libapp.so is present.",
             )
         }
 
-        // 16-byte window at the top of hidePremiumPopup(), unique in the 5.3.4 libapp.so:
-        //   bl   InitLateStaticFieldStub   ; de c0 16 94   (signature[0..4], PC-relative but stable here)
-        //   tbnz w0, #4, #0x8424c8         ; 60 02 20 37   (signature[4..8], the instruction we replace)
-        //   ldr  x0, [THR, #0x68]          ; 40 37 40 f9   (signature[8..12])
-        //   ldr  x0, [x0, #0x1d50]         ; 00 a8 4e f9   (signature[12..16], build-specific offset)
+        // 16-byte window at the top of hidePremiumPopup(), unique in the 6.6.11 libapp.so:
+        //   bl   InitLateStaticFieldStub   ; bc 5a 1c 94   (signature[0..4], PC-relative but stable here)
+        //   tbnz w0, #4, #0x93de70         ; a0 02 20 37   (signature[4..8], the instruction we replace)
+        //   ldr  x0, [THR, #0x78]          ; 40 3f 40 f9   (signature[8..12])
+        //   ldr  x0, [x0, #0x1c98]         ; 00 4c 4e f9   (signature[12..16], build-specific offset)
         val signature = intArrayOf(
-            0xDE, 0xC0, 0x16, 0x94, // bl   InitLateStaticFieldStub
-            0x60, 0x02, 0x20, 0x37, // tbnz w0, #4, #0x8424c8
-            0x40, 0x37, 0x40, 0xF9, // ldr  x0, [THR, #0x68]
-            0x00, 0xA8, 0x4E, 0xF9, // ldr  x0, [x0, #0x1d50]
+            0xBC, 0x5A, 0x1C, 0x94, // bl   InitLateStaticFieldStub
+            0xA0, 0x02, 0x20, 0x37, // tbnz w0, #4, #0x93de70
+            0x40, 0x3F, 0x40, 0xF9, // ldr  x0, [THR, #0x78]
+            0x00, 0x4C, 0x4E, 0xF9, // ldr  x0, [x0, #0x1c98]
         ).map { it.toByte() }.toByteArray()
 
-        // Replace the tbnz at signature offset 4 with an unconditional b #0x8424c8 (the function's own
-        // return-true block, 0x4c = 19 words ahead): word 0x14000013, little-endian 13 00 00 14.
+        // Replace the tbnz at signature offset 4 with an unconditional b #0x93de70 (the function's own
+        // return-true block, 0x54 = 21 words ahead): word 0x14000015, little-endian 15 00 00 14.
         val overwriteOffset = 4
         val overwrite = intArrayOf(
-            0x13, 0x00, 0x00, 0x14, // b #0x8424c8
+            0x15, 0x00, 0x00, 0x14, // b #0x93de70
         ).map { it.toByte() }.toByteArray()
 
         val bytes = lib.readBytes()
         val match = bytes.findUnique(signature)
             ?: throw PatchException(
-                "hidePremiumPopup signature not found in $libPath. This patch targets Cashew 5.3.4 " +
-                    "(arm64, Dart 3.1.3); a different build shifts these offsets and the signature must " +
+                "hidePremiumPopup signature not found in $libPath. This patch targets Cashew 6.6.11 " +
+                    "(arm64, Dart 3.12.2); a different build shifts these offsets and the signature must " +
                     "be re-derived with Blutter.",
             )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/collectr/premium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/collectr/premium/UnlockPremiumPatch.kt
@@ -10,13 +10,23 @@ import app.morphe.patcher.patch.rawResourcePatch
 // `membership.tier == pro` by loading the object field and comparing it to the const pro UserTier;
 // there is no single tier getter to hook. The one place that value is produced is Membership.fromJson,
 // which builds the membership the whole app reads. This patch forces fromJson to store tier=pro, which
-// flips every one of those gates at once. The bytes are machine code, so offsets shift between
-// releases and must be re-derived per version with Blutter; this is pinned to the 2.5.0 arm64 build.
+// flips every one of those gates at once.
+//
+// It also neutralizes the forced-update wall. Collectr's servers hand the client a minimum required
+// version; CollectrAppUpdater.showUpgradeDialogIfNeeded compares it against the installed version and,
+// when the install is older, shows a non-dismissible "Update App Required" dialog. A re-signed patched
+// build can't be updated through the Play Store, so once the server minimum moves past the pinned
+// version the app becomes unusable (issue #200). We force that method to take its own early-return
+// path so the dialog never shows, regardless of what minimum the server sends.
+//
+// The bytes are machine code, so offsets shift between releases and must be re-derived per version with
+// Blutter; this is pinned to the 2.5.6 arm64 build (version_code 737).
 @Suppress("unused")
 val unlockPremiumPatch = rawResourcePatch(
     name = "Unlock Premium",
     description = "Unlocks Collectr's premium features without a subscription, like unlimited " +
-        "collections, price alerts, and the advanced analytics. This is the arm64 build. Anything " +
+        "collections, price alerts, and the advanced analytics, and stops the blocking \"Update App " +
+        "Required\" popup that otherwise locks patched installs out. This is the arm64 build. Anything " +
         "Collectr serves from its own servers still needs the real subscription.",
 ) {
     compatibleWith(
@@ -24,7 +34,7 @@ val unlockPremiumPatch = rawResourcePatch(
             name = "Collectr",
             packageName = "com.collectrinc.collectr",
             appIconColor = 0x00204B,
-            targets = listOf(AppTarget("2.5.0")),
+            targets = listOf(AppTarget("2.5.6")),
         ),
     )
 
@@ -33,57 +43,97 @@ val unlockPremiumPatch = rawResourcePatch(
         val lib = get(libPath)
         if (!lib.exists()) {
             throw PatchException(
-                "$libPath not found in the APK. This targets the arm64 Collectr 2.5.0 build; apk-pure " +
-                    "serves a v7a-only bundle, so apply this to a merged arm64 universal built from a " +
-                    "Play Store .apks export (it carries split_config.arm64_v8a.apk). Merge it to a " +
-                    "universal with APKEditor m first.",
+                "$libPath not found in the APK. This targets the arm64 Collectr 2.5.6 build; apk-pure " +
+                    "serves a v7a-only bundle, so apply this to a merged arm64 universal built from an " +
+                    "arm64 XAPK (apkcombo lists one) or a Play Store .apks export (it carries " +
+                    "split_config.arm64_v8a.apk). Merge it to a universal with APKEditor m first.",
             )
         }
 
-        // 20-byte anchor inside Membership.fromJson, right where firstWhere() picks the tier enum from
-        // the parsed JSON and saves it to the local slot the constructor later stores into tier. This
-        // window is unique in the 2.5.0 libapp.so:
-        //   ldr  x4, [x27, #0xc8]      ; firstWhere call descriptor   (kept, signature[0..4])
+        val bytes = lib.readBytes()
+
+        // --- Force Membership.tier = pro -------------------------------------------------------------
+        // 20-byte anchor inside Membership.fromJson (0x94abc0), right where firstWhere() picks the tier
+        // enum from the parsed JSON and saves it to the local slot the constructor later stores into
+        // tier. This window is unique in the 2.5.6 libapp.so:
+        //   ldr  x4, [x27, #0xd0]     ; firstWhere call descriptor   (kept, signature[0..4])
         //   bl   firstWhere           ; pick the matching UserTier    (replaced)
         //   mov  x1, x0               ; x1 = picked tier              (replaced)
         //   ldur x0, [x29, #-0x10]    ; reload the context            (replaced, re-emitted below)
         //   stur x1, [x29, #-8]       ; save tier to the local slot   (kept, signature[16..20])
-        val signature = intArrayOf(
-            0x64, 0x67, 0x40, 0xf9, // ldr  x4, [x27, #0xc8]
-            0xe1, 0xd8, 0xfd, 0x97, // bl   firstWhere
+        val tierSignature = intArrayOf(
+            0x64, 0x6b, 0x40, 0xf9, // ldr  x4, [x27, #0xd0]
+            0x7b, 0x6e, 0xfd, 0x97, // bl   firstWhere
             0xe1, 0x03, 0x00, 0xaa, // mov  x1, x0
             0xa0, 0x03, 0x5f, 0xf8, // ldur x0, [x29, #-0x10]
             0xa1, 0x83, 0x1f, 0xf8, // stur x1, [x29, #-8]
-        ).map { it.toByte() }.toByteArray()
+        ).toByteArray()
 
         // Overwrite the 12 bytes at signature offset 4 (bl firstWhere, mov, ldur). The firstWhere result
         // is only ever consumed through the stur into [x29,#-8], so dropping the call is safe. We move
         // the context reload up so x0 is still live for the JSON read that follows, then materialize the
-        // const pro UserTier the same way the app does everywhere else (the PP table at slot 0x13548):
+        // const pro UserTier the same way the app does everywhere else (the PP table at slot 0x15728,
+        // confirmed as UserTier index 1 "pro"; free is 0x17a78, hidden is 0x2b448):
         //   ldur x0, [x29, #-0x10]    ; context reload moved up (x0 still needed at the next instruction)
-        //   add  x1, x27, #0x13, lsl #12
-        //   ldr  x1, [x1, #0x548]     ; x1 = const UserTier 'pro' (PP+0x13548)
+        //   add  x1, x27, #0x15, lsl #12
+        //   ldr  x1, [x1, #0x728]     ; x1 = const UserTier 'pro' (PP+0x15728)
         // The kept stur x1, [x29, #-8] then saves pro, so the constructor stores tier=pro. The membership
-        // allocation and the other field stores are untouched, and the edit is length preserving.
-        val overwriteOffset = 4
-        val overwrite = intArrayOf(
+        // allocation and the other field stores are untouched, and the edit is length preserving (no new
+        // bl; the dropped firstWhere is why an earlier build that dropped the allocate stub SIGSEGV'd).
+        val tierOverwriteOffset = 4
+        val tierOverwrite = intArrayOf(
             0xa0, 0x03, 0x5f, 0xf8, // ldur x0, [x29, #-0x10]
-            0x61, 0x4f, 0x40, 0x91, // add  x1, x27, #0x13, lsl #12
-            0x21, 0xa4, 0x42, 0xf9, // ldr  x1, [x1, #0x548]
-        ).map { it.toByte() }.toByteArray()
+            0x61, 0x57, 0x40, 0x91, // add  x1, x27, #0x15, lsl #12
+            0x21, 0x94, 0x43, 0xf9, // ldr  x1, [x1, #0x728]
+        ).toByteArray()
 
-        val bytes = lib.readBytes()
-        val match = bytes.findUnique(signature)
+        val tierMatch = bytes.findUnique(tierSignature)
             ?: throw PatchException(
-                "Membership tier signature not found in $libPath. This patch targets Collectr 2.5.0 " +
+                "Membership tier signature not found in $libPath. This patch targets Collectr 2.5.6 " +
                     "(arm64); a different build shifts these offsets and the signature must be " +
                     "re-derived with Blutter.",
             )
+        tierOverwrite.forEachIndexed { i, b -> bytes[tierMatch + tierOverwriteOffset + i] = b }
 
-        overwrite.forEachIndexed { i, b -> bytes[match + overwriteOffset + i] = b }
+        // --- Kill the forced "Update App Required" dialog --------------------------------------------
+        // 24-byte anchor at the top of CollectrAppUpdater.showUpgradeDialogIfNeeded (0xb418b0), covering
+        // its async null-check and the return-null tail that the null case already uses. This window is
+        // unique in the 2.5.6 libapp.so (the b to ReturnAsyncNotFuture and the bl to PackageInfo
+        // .fromPlatform pin it):
+        //   ldur x0, [x29, #-0x20]    ; x0 = the server update payload   (kept)
+        //   cmp  w0, NULL                                                (kept)
+        //   b.ne #0xb418c4            ; if payload != null, run the version check  (replaced with NOP)
+        //   mov  x0, NULL             ; return-null path                 (kept)
+        //   b    ReturnAsyncNotFuture ; return                           (kept)
+        //   bl   PackageInfo.fromPlatform                                (kept, anchor only)
+        // NOP-ing the b.ne makes the method always fall through to its existing "no payload -> return"
+        // path, so it never reaches the version comparison or showDialog. The one caller (main startup)
+        // ignores the result, so returning early has no other effect. Length preserving; no new bl.
+        val updateSignature = intArrayOf(
+            0xa0, 0x03, 0x5e, 0xf8, // ldur x0, [x29, #-0x20]
+            0x1f, 0x00, 0x16, 0x6b, // cmp  w0, NULL
+            0x61, 0x00, 0x00, 0x54, // b.ne #0xb418c4
+            0xe0, 0x03, 0x16, 0xaa, // mov  x0, NULL
+            0xe0, 0x14, 0xeb, 0x17, // b    ReturnAsyncNotFuture
+            0xe1, 0x0b, 0xf8, 0x97, // bl   PackageInfo.fromPlatform
+        ).toByteArray()
+
+        val updateBranchOffset = 8
+        val nop = intArrayOf(0x1f, 0x20, 0x03, 0xd5).toByteArray() // nop
+
+        val updateMatch = bytes.findUnique(updateSignature)
+            ?: throw PatchException(
+                "Force-update signature not found in $libPath. This patch targets Collectr 2.5.6 " +
+                    "(arm64); a different build shifts these offsets and the signature must be " +
+                    "re-derived with Blutter.",
+            )
+        nop.forEachIndexed { i, b -> bytes[updateMatch + updateBranchOffset + i] = b }
+
         lib.writeBytes(bytes)
     }
 }
+
+private fun IntArray.toByteArray(): ByteArray = map { it.toByte() }.toByteArray()
 
 // Returns the single start index of [pattern], or null if absent. Throws on more than one match: an
 // ambiguous machine-code signature is too weak to overwrite blindly.
@@ -95,7 +145,7 @@ private fun ByteArray.findUnique(pattern: ByteArray): Int? {
             if (this[i + j] != pattern[j]) continue@outer
         }
         if (found != null) {
-            throw PatchException("Membership tier signature is ambiguous (matched more than once).")
+            throw PatchException("Collectr libapp.so signature is ambiguous (matched more than once).")
         }
         found = i
     }

--- a/patches/src/main/kotlin/hooman/morphe/patches/cronometer/gold/UnlockGoldPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/cronometer/gold/UnlockGoldPatch.kt
@@ -9,7 +9,9 @@ import app.morphe.patcher.patch.rawResourcePatch
 // fingerprint. Gold is gated on one cached override (Blutter's field_63) on the User singleton, set
 // from the account payload. NOP-ing the tbnz in its setter makes the bool always store true, which
 // unlocks every Gold gate at once. Offsets shift between releases, so match a byte signature
-// anchored on the field_63 store and refuse to patch if it isn't uniquely present.
+// anchored on the field store and refuse to patch if it isn't uniquely present. Each supported build
+// gets its own signature and we apply whichever one is uniquely present; 4.56.0 and 4.57.2 store to
+// field_63 and share the exact same setter bytes, so one signature covers both.
 @Suppress("unused")
 val unlockGoldPatch = rawResourcePatch(
     name = "Unlock Gold",
@@ -22,7 +24,7 @@ val unlockGoldPatch = rawResourcePatch(
             name = "Cronometer",
             packageName = "com.cronometer.android.gold",
             appIconColor = 0xF26B21,
-            targets = listOf(AppTarget("4.56.0")),
+            targets = listOf(AppTarget("4.56.0"), AppTarget("4.57.2")),
         ),
     )
 
@@ -39,23 +41,30 @@ val unlockGoldPatch = rawResourcePatch(
             )
         }
 
+        // One signature per supported build; each is the setter's 7-instruction sequence:
         // tbnz w0,#4,+0xc | add x2,NULL,#0x20 (true) | b +8 | add x2,NULL,#0x30 (false)
-        // | ldur x0,[fp,#-0x18] | ldur x1,[fp,#-8] | stur w2,[x0,#0x63]  (field_63 store)
-        val signature = intArrayOf(
-            0x60, 0x00, 0x20, 0x37, // tbnz w0, #4, +0xc   <- patched to NOP
-            0xC2, 0x82, 0x00, 0x91, // add  x2, NULL, #0x20  (true)
-            0x02, 0x00, 0x00, 0x14, // b    +0x8
-            0xC2, 0xC2, 0x00, 0x91, // add  x2, NULL, #0x30  (false)
-            0xA0, 0x83, 0x5E, 0xF8, // ldur x0, [fp, #-0x18]
-            0xA1, 0x83, 0x5F, 0xF8, // ldur x1, [fp, #-8]
-            0x02, 0x30, 0x06, 0xB8, // stur w2, [x0, #0x63]  (User.field_63 = gold override)
-        ).map { it.toByte() }.toByteArray()
+        // | ldur x0,[fp,#-0x18] | ldur x1,[fp,#-8] | stur w2,[x0,#<field off>]  (field store)
+        // The leading tbnz (first 4 bytes) is what gets NOP-ed. 4.56.0 and 4.57.2 store to field_63
+        // and are byte-identical, so one entry covers both; a version that moves the offset adds one.
+        val signatures = listOf(
+            intArrayOf(
+                0x60, 0x00, 0x20, 0x37, // tbnz w0, #4, +0xc   <- patched to NOP
+                0xC2, 0x82, 0x00, 0x91, // add  x2, NULL, #0x20  (true)
+                0x02, 0x00, 0x00, 0x14, // b    +0x8
+                0xC2, 0xC2, 0x00, 0x91, // add  x2, NULL, #0x30  (false)
+                0xA0, 0x83, 0x5E, 0xF8, // ldur x0, [fp, #-0x18]
+                0xA1, 0x83, 0x5F, 0xF8, // ldur x1, [fp, #-8]
+                0x02, 0x30, 0x06, 0xB8, // stur w2, [x0, #0x63]  (User.field_63 = gold override; 4.56.0 + 4.57.2)
+            ).map { it.toByte() }.toByteArray(),
+        )
 
         val bytes = lib.readBytes()
-        val match = bytes.findUnique(signature)
+        // Apply whichever signature is uniquely present. findUnique throws if a signature matches
+        // more than once, so an ambiguous match is a hard error rather than a blind patch.
+        val match = signatures.firstNotNullOfOrNull { bytes.findUnique(it) }
             ?: throw PatchException(
                 "Gold-override signature not found in $libPath. This patch targets " +
-                    "Cronometer 4.56.0 (arm64); the AOT layout likely changed in a newer " +
+                    "Cronometer 4.56.0 and 4.57.2 (arm64); the AOT layout likely changed in a newer " +
                     "build and the signature must be re-derived.",
             )
 

--- a/patches/src/main/kotlin/hooman/morphe/patches/foldersync/premium/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/foldersync/premium/UnlockPremiumPatch.kt
@@ -20,15 +20,47 @@ val unlockPremiumPatch = bytecodePatch(
             name = "FolderSync",
             packageName = "dk.tacit.android.foldersync.lite",
             appIconColor = 0x406FB8,
-            targets = listOf(AppTarget("4.9.3")),
+            targets = listOf(AppTarget("4.9.3"), AppTarget("4.12.0")),
         ),
     )
 
     execute {
-        // Premium funnels through one read: getPremiumVersionPurchased() ("premium_version" pref, false
-        // for a free account). Every VersionFeaturesConfig derives isPaidVersion/showAds from it, and the
-        // only writer is the Play Billing result (never true for a non-owner), so forcing it true unlocks
-        // premium and turns ads off app-wide, reset-proof.
+        // The real gate is VersionFeaturesConfig. Every premium/ad consumer reads one off the
+        // AppLiteVersionFeatures StateFlow: field b = isPaidVersion (unlocks premium), a() = showAds
+        // (returns false once paid), c/d = the account and sync-pair limits (already Int.MAX in the
+        // lite build). The config is seeded from getPremiumVersionPurchased(), but a billing
+        // coroutine rebuilds it live: after the Play check fails for a non-owner it calls
+        // setPremiumVersionPurchased(false), which pushes a fresh PreferenceState into the flow that
+        // AppLiteVersionFeatures collects and turns back into a config with isPaidVersion = false.
+        // So forcing only the pref getter is overwritten a moment later. Force the field at its one
+        // write point instead: the 4-arg data-class constructor. Every config the app builds --
+        // initial seed and every rebuild -- then stores isPaidVersion = true, so premium stays on and
+        // ads stay off regardless of the billing result, and the limits carry through untouched.
+        val config = mutableClassDefByOrNull("Ldk/tacit/foldersync/services/VersionFeaturesConfig;")
+            ?: throw PatchException(
+                "FolderSync: VersionFeaturesConfig not found — package layout changed.",
+            )
+
+        val configCtor = config.methods.firstOrNull { method ->
+            method.name == "<init>" &&
+                method.returnType == "V" &&
+                method.parameterTypes.map { it.toString() } == listOf(
+                    "Ldk/tacit/foldersync/services/VersionIdentifier;", "Z", "I", "I",
+                )
+        }
+            ?: throw PatchException(
+                "FolderSync: VersionFeaturesConfig(VersionIdentifier, Z, I, I) constructor not found " +
+                    "— the version-features shape changed.",
+            )
+
+        // p2 is the isPaidVersion argument; overwrite it before the constructor's iput-boolean stores
+        // it into field b. p2 is used only for that store, so this is safe.
+        configCtor.addInstructions(0, "const/4 p2, 0x1")
+
+        // Belt and suspenders: keep the pref getter forced too. It seeds the initial config, backs
+        // the settings "premium" row, and feeds any direct reader that skips VersionFeaturesConfig.
+        // Premium funnels through this read ("premium_version" pref, false for a free account) and the
+        // only writer is the Play Billing result (never true for a non-owner).
         val prefs = mutableClassDefByOrNull("Ldk/tacit/foldersync/services/AppPreferenceManager;")
             ?: throw PatchException(
                 "FolderSync: AppPreferenceManager not found — package layout changed.",


### PR DESCRIPTION
Adds support for the latest versions of five apps, all verified on a device.

- FolderSync 4.12.0 — Unlock Premium. The live gate is VersionFeaturesConfig (a billing coroutine rebuilds it and clobbered the old pref force), so the flag is forced at the config constructor.
- Cashew 6.6.11 — Unlock Pro. Re-derived the Flutter hidePremiumPopup signature for the new build.
- Adobe Acrobat 26.7.1.47181 — Unlock Pro. Gate selection is now shape/pref-string based instead of R8 method names, so it stops breaking every release; the Edit dynamic-feature gate is forced so Edit opens with the base fonts (Create/Export PDF stay server-side).
- Collectr 2.5.6 — Unlock Premium, and neutralizes the server-driven forced-update wall.
- Cronometer 4.57.2 — Unlock Gold, added alongside 4.56.0 (4.57.3+ adds native PairIP that can't be bypassed on a re-signed build).