### PR TITLE
fix: Twitch emotes patch no longer breaks chat

### DIFF
--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -1,3 +1,16 @@
--keep class app.morphe.extension.twitch.emotes.EmoteSupport {
-    public static *;
-}
+# Extension classes are merged into the host app's dex. The host is itself R8-obfuscated and its
+# classes occupy bare root-package names (a, b, c, ...). If R8 renames an extension class to a bare
+# name too, it collides with a host class of the same name, and after the merge the reference resolves
+# to the host's class. That breaks class verification: e.g. EmoteImageLoader's LruCache subclass gets
+# renamed to `o`, but the merged `o` is an unrelated host class, so ART rejects EmoteSupport with
+# "Reference: o not instance of android.util.LruCache" and the whole feature (and chat) dies. (#196)
+#
+# Keep every extension class at its fully-qualified name so it can never collide with a host class.
+# Member obfuscation would be safe (members are class-scoped), but the extension is tiny, so keep it
+# whole for simplicity and readable merged output.
+-keep class app.morphe.extension.** { *; }
+
+# The keep above cannot cover R8-synthesised classes (lambda impls, API-desugaring outlines), which R8
+# otherwise emits with bare names in the root package and which then collide with host classes the same
+# way. Force every class R8 does rename into the extension package so none land in the root namespace.
+-repackageclasses 'app.morphe.extension.twitch.emotes'

--- a/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteSupport.java
+++ b/extensions/twitch/src/main/java/app/morphe/extension/twitch/emotes/EmoteSupport.java
@@ -27,19 +27,27 @@ public final class EmoteSupport {
             new View.OnAttachStateChangeListener() {
                 @Override
                 public void onViewAttachedToWindow(View view) {
-                    TextView textView = (TextView) view;
-                    BoundMessage message;
-                    synchronized (LOCK) {
-                        message = BOUND_MESSAGES.get(textView);
-                    }
-                    if (message != null) {
-                        scheduleRender(textView, message);
+                    // Runs on the chat RecyclerView's views; a throw here would be uncaught on the UI
+                    // thread and crash Twitch, so keep it contained.
+                    try {
+                        TextView textView = (TextView) view;
+                        BoundMessage message;
+                        synchronized (LOCK) {
+                            message = BOUND_MESSAGES.get(textView);
+                        }
+                        if (message != null) {
+                            scheduleRender(textView, message);
+                        }
+                    } catch (Throwable ignored) {
                     }
                 }
 
                 @Override
                 public void onViewDetachedFromWindow(View view) {
-                    stopAnimations(((TextView) view).getText());
+                    try {
+                        stopAnimations(((TextView) view).getText());
+                    } catch (Throwable ignored) {
+                    }
                 }
             };
 
@@ -48,17 +56,44 @@ public final class EmoteSupport {
     private EmoteSupport() {
     }
 
+    // Patched into Twitch's ChannelChatConnectionKey constructor. That constructor has no handler of
+    // its own, so a throw here would abort chat-connection setup; never let anything escape. (#196)
     public static void onChannelChanged(String channelId, String channelName) {
-        String normalized = normalizeChannelId(channelId);
-        if (normalized != null) {
-            lastRoomId = normalized;
+        try {
+            String normalized = normalizeChannelId(channelId);
+            if (normalized != null) {
+                lastRoomId = normalized;
+            }
+        } catch (Throwable ignored) {
         }
     }
 
+    // Patched in right after Twitch's own setText in the chat-row binder (udc.D). That binder runs
+    // inside RecyclerView.onBindViewHolder and has no try/catch, so anything thrown here unwinds
+    // through the adapter and takes out the whole chat list and message input. This hook must never
+    // throw. (#196)
     public static void bind(TextView textView, String sourceChannelId) {
         if (textView == null) {
             return;
         }
+        try {
+            bindInternal(textView, sourceChannelId);
+        } catch (Throwable ignored) {
+            forget(textView);
+        }
+    }
+
+    private static void forget(TextView textView) {
+        try {
+            synchronized (LOCK) {
+                BOUND_MESSAGES.remove(textView);
+            }
+            textView.removeOnAttachStateChangeListener(VIEW_LIFECYCLE);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static void bindInternal(TextView textView, String sourceChannelId) {
         CharSequence current = textView.getText();
         synchronized (LOCK) {
             BOUND_MESSAGES.remove(textView);
@@ -86,6 +121,15 @@ public final class EmoteSupport {
     }
 
     private static void render(TextView textView, BoundMessage message) {
+        // Reached on the UI thread from bind and from posted refreshes; contain any failure so a bad
+        // emote/image can never crash Twitch or blank the row.
+        try {
+            renderInternal(textView, message);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static void renderInternal(TextView textView, BoundMessage message) {
         synchronized (LOCK) {
             if (BOUND_MESSAGES.get(textView) != message) {
                 return;
@@ -205,28 +249,36 @@ public final class EmoteSupport {
         return trimmed;
     }
 
+    // Invoked from the catalog/image executor threads. An uncaught throw here would be fatal to the
+    // whole app, so keep it contained.
     private static void refreshImage(String url) {
-        List<Map.Entry<TextView, BoundMessage>> snapshot = boundMessages();
-        for (Map.Entry<TextView, BoundMessage> entry : snapshot) {
-            TextView textView = entry.getKey();
-            BoundMessage message = entry.getValue();
-            if (textView != null && message != null && message.pendingImages.contains(url)) {
-                scheduleRender(textView, message);
+        try {
+            List<Map.Entry<TextView, BoundMessage>> snapshot = boundMessages();
+            for (Map.Entry<TextView, BoundMessage> entry : snapshot) {
+                TextView textView = entry.getKey();
+                BoundMessage message = entry.getValue();
+                if (textView != null && message != null && message.pendingImages.contains(url)) {
+                    scheduleRender(textView, message);
+                }
             }
+        } catch (Throwable ignored) {
         }
     }
 
     private static void refreshCatalog(String channelId) {
-        List<Map.Entry<TextView, BoundMessage>> snapshot = boundMessages();
-        for (Map.Entry<TextView, BoundMessage> entry : snapshot) {
-            TextView textView = entry.getKey();
-            BoundMessage message = entry.getValue();
-            if (textView == null || message == null) {
-                continue;
+        try {
+            List<Map.Entry<TextView, BoundMessage>> snapshot = boundMessages();
+            for (Map.Entry<TextView, BoundMessage> entry : snapshot) {
+                TextView textView = entry.getKey();
+                BoundMessage message = entry.getValue();
+                if (textView == null || message == null) {
+                    continue;
+                }
+                if (channelId == null || channelId.equals(message.channelId)) {
+                    scheduleRender(textView, message);
+                }
             }
-            if (channelId == null || channelId.equals(message.channelId)) {
-                scheduleRender(textView, message);
-            }
+        } catch (Throwable ignored) {
         }
     }
 


### PR DESCRIPTION
Bug fix for #196. The shipped 7TV/BTTV emotes extension failed ART class verification once merged into Twitch's dex (its R8-minified classes collided with the host's bare-name classes), so the class never loaded and the chat-row bind threw a VerifyError — blanking the whole chat list and disabling the input box. Fix keeps the extension classes fully-qualified via proguard so they can't collide, plus guards the extension entry points. Device-verified: chat renders and input works again. Emote rendering itself is a separate follow-up (still being finalized) and is not claimed here.