### PR TITLE
fix: Tumblr Remove ads now drops server-inserted sponsored posts

### DIFF
--- a/patches/src/main/kotlin/hooman/morphe/patches/tumblr/ads/RemoveAdsPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/tumblr/ads/RemoveAdsPatch.kt
@@ -57,15 +57,62 @@ val removeAdsPatch = bytecodePatch(
             """,
         )
 
-        // Part 2 -- Blaze posts: dashboard items someone paid to promote, which the ad gate above does
-        // not catch. They arrive two ways. A promoted regular Post carries isBlazed=true (or
-        // isTumblrSponsoredPost=true for Tumblr's own). The newer "blazed_post" timeline type instead
-        // wraps the Post in a BlazedPost (BlazedPost implements Timelineable directly, it does NOT
-        // extend Post), so an instance-of Post test alone misses it and the promo slips through.
-        // Every item runs through the timeline-object factory nf0.c0.b(); returning null there drops it
-        // before the feed builder collects it. Drop any BlazedPost outright, and drop a Post when either
-        // blaze flag is set (Post.q1()=getIsBlazed, K1()=getIsTumblrSponsoredPost, both R8-renamed),
-        // else fall through to the original factory.
+        // Part 2 -- server-inserted sponsored/promoted items the ad gate above does not catch. Part 1
+        // disables the client ad SDKs (Nimbus and the others check UserInfo.v0() at startup), but the
+        // dashboard response still carries ad/sponsored objects the server places directly, so those
+        // keep rendering:
+        //   - Blaze/promoted posts. A promoted regular Post carries isBlazed=true (or
+        //     isTumblrSponsoredPost=true for Tumblr's own). The "blazed_post" type instead wraps the
+        //     Post in a BlazedPost, which implements Timelineable directly (it does NOT extend Post), so
+        //     an instance-of Post test alone misses it.
+        //   - Server ad/sponsored cards. sponsored_day (RichBanner) and takeover_banner (Banner) extend
+        //     SimpleAd; backfill_ad (BackFillAdResponse) and the SDK ad payloads (Nimbus, Facebook,
+        //     Vungle, DisplayIO) are SimpleAd/ServerSideAd; client_side_ad and client_side_ad_waterfall
+        //     are ClientAd / ClientSideAdMediation. None of these pass through the client SDK gate, so
+        //     they render as in-feed sponsored posts.
+        // Every dashboard item is built by the one timeline-object factory (pinned by the Vungle cast
+        // string); returning null there drops the item before the feed builder collects it. The rumblr
+        // model is unobfuscated and every subtype of SimpleAd / ServerSideAd / ClientAd is a dedicated
+        // ad class (never an organic post), so an instance-of on the base is a safe, R8-stable drop that
+        // leaves the following feed and reblogs untouched.
+        //
+        // The class descriptors are blind-injected refs, so verify each one is present -- a model rename
+        // then fails loud at apply instead of silently matching nothing and letting ads back in. The
+        // getters are the exception R8 does rename: q1()=getIsBlazed and K1()=getIsTumblrSponsoredPost
+        // were re-derived from the Moshi ctor params (is_blazed -> field z1, is_tumblr_sponsored_post ->
+        // field N0) for 45.8.0.110. The shape check below only catches a rename/removal; re-verify the
+        // semantics against the decoded model on every bump.
+        val post = mutableClassDefByOrNull("Lcom/tumblr/rumblr/model/post/Post;")
+            ?: throw PatchException("Tumblr: com.tumblr.rumblr.model.post.Post not found -- model changed.")
+
+        val requiredModelClasses = listOf(
+            "Lcom/tumblr/rumblr/model/ClientAd;",
+            "Lcom/tumblr/rumblr/model/ClientSideAdMediation;",
+            "Lcom/tumblr/rumblr/model/advertising/ServerSideAd;",
+            "Lcom/tumblr/rumblr/model/advertising/SimpleAd;",
+            "Lcom/tumblr/rumblr/model/BlazedPost;",
+        )
+        val missing = requiredModelClasses.filter { mutableClassDefByOrNull(it) == null }
+        if (missing.isNotEmpty()) {
+            throw PatchException(
+                "Tumblr: ad/sponsored model classes missing, the timeline model changed -- re-derive: " +
+                    missing.joinToString(),
+            )
+        }
+
+        val hasBlazedGetter = post.methods.any {
+            it.name == "q1" && it.returnType == "Z" && it.parameterTypes.isEmpty()
+        }
+        val hasSponsoredGetter = post.methods.any {
+            it.name == "K1" && it.returnType == "Ljava/lang/Boolean;" && it.parameterTypes.isEmpty()
+        }
+        if (!hasBlazedGetter || !hasSponsoredGetter) {
+            throw PatchException(
+                "Tumblr: Post blaze getters q1()Z / K1()Ljava/lang/Boolean; not found with the expected " +
+                    "shape -- R8 renamed them; re-derive from the Moshi model.",
+            )
+        }
+
         val factory = TimelineObjectFactoryFingerprint.method
         factory.addInstructionsWithLabels(
             0,
@@ -73,6 +120,14 @@ val removeAdsPatch = bytecodePatch(
                 if-eqz p1, :original
                 invoke-virtual {p1}, Lcom/tumblr/rumblr/model/TimelineObject;->getData()Lcom/tumblr/rumblr/model/Timelineable;
                 move-result-object v0
+                instance-of v1, v0, Lcom/tumblr/rumblr/model/ClientAd;
+                if-nez v1, :drop
+                instance-of v1, v0, Lcom/tumblr/rumblr/model/ClientSideAdMediation;
+                if-nez v1, :drop
+                instance-of v1, v0, Lcom/tumblr/rumblr/model/advertising/ServerSideAd;
+                if-nez v1, :drop
+                instance-of v1, v0, Lcom/tumblr/rumblr/model/advertising/SimpleAd;
+                if-nez v1, :drop
                 instance-of v1, v0, Lcom/tumblr/rumblr/model/BlazedPost;
                 if-nez v1, :drop
                 instance-of v1, v0, Lcom/tumblr/rumblr/model/post/Post;


### PR DESCRIPTION
The Remove ads patch forced UserInfo.v0() false (disables the client ad SDKs) and dropped Blaze/sponsored Posts at the timeline-object factory, but the dashboard response also carries server-inserted ad/sponsored Timelineable types the factory built untouched (backfill_ad, sponsored_day, takeover_banner, client_side_ad and the SDK ad payloads), so those still rendered as in-feed sponsored posts.

This drops any ClientAd / ClientSideAdMediation / advertising.ServerSideAd / advertising.SimpleAd at the same factory chokepoint before the Post check (every subtype is a dedicated ad class, so the following feed and reblogs stay untouched), and fails loud at apply if any model class or the blaze getters change shape.

Target Tumblr 45.8.0.110. Verified on device: dashboard clean of sponsored/promoted cards, organic feed and reblogs intact.