### PR TITLE
feat: Add 'No date first' patch for Todoist

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ Personal [Morphe](https://morphe.software) patches for paid Android apps.
 </details>
 
 <details>
+<summary>📦 Todoist&nbsp;&nbsp;•&nbsp;&nbsp;2 patches</summary>
+<br>
+
+**🎯 Supported versions:**
+
+| v12190 |
+| :---: |
+
+| 💊&nbsp;Patch | 📜&nbsp;Description | ⚙️&nbsp;Options |
+|----------|----------------|-----------|
+| [No date first](#no-date-first) | Moves undated tasks to the top of the task list in grouped views, so tasks without a due date appear before dated ones. The reordering is applied on the client side when the section list is built; synced data and server behaviour are untouched. |  |
+| [Unlock Pro](#unlock-pro) | Turns on Todoist Pro on the signed-in account: the project, task, section, filter and label caps go to unlimited, reminders, comments, deadlines, durations, calendar layout, the activity log, file uploads and the paid templates all open, and the plan badge reads Pro. Pro on Todoist is a plan the server sends down and the app caches, so the unlock takes hold once a signed-in account loads and it holds across a sync. Anything the Todoist server runs itself is untouched: the AI assistant, real team/Business collaboration, and server-enforced storage still need a paid account. Re-signing breaks Google sign-in, so sign in with email and password. |  |
+
+</details>
+
+<details>
 <summary>📦 SofaScore&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
 <br>
 
@@ -626,21 +642,6 @@ Personal [Morphe](https://morphe.software) patches for paid Android apps.
 | 💊&nbsp;Patch | 📜&nbsp;Description | ⚙️&nbsp;Options |
 |----------|----------------|-----------|
 | [Unlock Pro](#unlock-pro) | Turns on Stash Pro and removes the ads. Pro is a flag the server sends with your account, so the unlock takes effect on a signed-in account once it loads. With it on the ads go away and the Pro-gated UI opens up: the Become Pro upsell card, the home screen block layout, custom collection cover images, and the locked review detail fields. Anything the Stash server checks for a non-paying account is unaffected, so data kept behind a paid account does not sync. Re-signing breaks Google and Facebook login, so sign in with email. |  |
-
-</details>
-
-<details>
-<summary>📦 Todoist&nbsp;&nbsp;•&nbsp;&nbsp;1 patch</summary>
-<br>
-
-**🎯 Supported versions:**
-
-| v12190 |
-| :---: |
-
-| 💊&nbsp;Patch | 📜&nbsp;Description | ⚙️&nbsp;Options |
-|----------|----------------|-----------|
-| [Unlock Pro](#unlock-pro) | Turns on Todoist Pro on the signed-in account: the project, task, section, filter and label caps go to unlimited, reminders, comments, deadlines, durations, calendar layout, the activity log, file uploads and the paid templates all open, and the plan badge reads Pro. Pro on Todoist is a plan the server sends down and the app caches, so the unlock takes hold once a signed-in account loads and it holds across a sync. Anything the Todoist server runs itself is untouched: the AI assistant, real team/Business collaboration, and server-enforced storage still need a paid account. Re-signing breaks Google sign-in, so sign in with email and password. |  |
 
 </details>
 

--- a/patches-list.json
+++ b/patches-list.json
@@ -448,6 +448,31 @@
       "options": []
     },
     {
+      "name": "No date first",
+      "description": "Moves undated tasks to the top of the task list in grouped views, so tasks without a due date appear before dated ones. The reordering is applied on the client side when the section list is built; synced data and server behaviour are untouched.",
+      "default": true,
+      "dependencies": [],
+      "compatiblePackages": [
+        {
+          "packageName": "com.todoist",
+          "name": "Todoist",
+          "description": null,
+          "apkFileType": null,
+          "appIconColor": "#E44332",
+          "signatures": null,
+          "targets": [
+            {
+              "version": "v12190",
+              "isExperimental": false,
+              "minSdk": null,
+              "description": null
+            }
+          ]
+        }
+      ],
+      "options": []
+    },
+    {
       "name": "Remove Ads",
       "description": "Stops the banner and interstitial ads SofaScore shows around scores and between screens. Every ad site reads one decision method off the cached account, and the app's own ad master switch caches that method's result, so forcing it to \"no ads\" turns them all off with no login needed. The result holds across a sync because the switch re-reads the same method. Ads that are served by the video/story SDK inside embedded content are not affected. The patch also keeps Firebase notification registration compatible with the re-signed build. Re-signing breaks SofaScore's login (it only offers Google and Facebook sign-in, both of which reject the new signature), but removing ads does not need an account so the patch still works.",
       "default": true,

--- a/patches/src/main/kotlin/hooman/morphe/patches/todoist/nodatefirst/NoDateFirstPatch.kt
+++ b/patches/src/main/kotlin/hooman/morphe/patches/todoist/nodatefirst/NoDateFirstPatch.kt
@@ -1,0 +1,98 @@
+package hooman.morphe.patches.todoist.nodatefirst
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
+import app.morphe.patcher.util.smali.ExternalLabel
+
+// Todoist groups tasks in views (Upcoming, Project Date Grouping, Deadline Grouping) using a
+// null-aware Comparator wrapper (Kotlin's nullsLast comparator class `gz.b`). When grouping items by
+// date in a TreeMap, null keys represent undated tasks ("No date" / "Sans date").
+//
+// The standard nullsLast comparator returns 1 when the first object is null, causing TreeMap to
+// place the "No date" section at the very END of the list.
+//
+// This patch locates the nullsLast Comparator class (Lgz/b;) and prepends nullsFirst logic to its
+// compare() method to return -1 when the first object is null. As a result, TreeMap places the
+// undated section at the TOP of the list.
+@Suppress("unused")
+val noDateFirstPatch = bytecodePatch(
+    name = "No date first",
+    description = "Moves undated tasks to the top of the task list in grouped views, so " +
+        "tasks without a due date appear before dated ones. The reordering is applied on the " +
+        "client side when the section list is built; synced data and server behaviour are " +
+        "untouched.",
+) {
+    compatibleWith(
+        Compatibility(
+            name = "Todoist",
+            packageName = "com.todoist",
+            // Todoist's brand red.
+            appIconColor = 0xE44332,
+            targets = listOf(AppTarget("v12190")),
+        ),
+    )
+
+    execute {
+        // Locate the nullsLast Comparator wrapper class (Lgz/b;) or find it by its single
+        // Comparator field signature.
+        val nullsLastClassDef = classDefByOrNull("Lgz/b;")
+            ?: classDefByStrings("Ljava/util/Comparator;")
+                .singleOrNull { classDef ->
+                    classDef.interfaces.contains("Ljava/util/Comparator;") &&
+                        classDef.fields.count() == 1 &&
+                        classDef.fields.first().type == "Ljava/util/Comparator;" &&
+                        classDef.methods.any { method ->
+                            method.name == "compare" &&
+                                method.parameterTypes.size == 2 &&
+                                method.parameterTypes[0] == "Ljava/lang/Object;" &&
+                                method.parameterTypes[1] == "Ljava/lang/Object;"
+                        }
+                }
+            ?: throw PatchException(
+                "Todoist: nullsLast Comparator class (Lgz/b;) was not found. " +
+                    "The comparator structure changed; re-derive.",
+            )
+
+        patchNullsLastComparator(mutableClassDefBy(nullsLastClassDef))
+    }
+}
+
+// Prepends nullsFirst logic at compare(p1, p2) entry:
+//   if p1 == p2 -> return 0
+//   if p1 == null (if-eqz p1) -> return -1  (nullsFirst: null comes before non-null)
+//   if p2 == null (if-eqz p2) -> return 1   (nullsFirst: non-null comes before null)
+//   else -> goto original comparator.compare(p1, p2)
+private fun BytecodePatchContext.patchNullsLastComparator(comparatorClass: MutableClass) {
+    val compareMethod = comparatorClass.methods.singleOrNull { method ->
+        method.name == "compare" &&
+            method.parameterTypes.size == 2 &&
+            method.parameterTypes[0] == "Ljava/lang/Object;" &&
+            method.parameterTypes[1] == "Ljava/lang/Object;"
+    } ?: throw PatchException("Todoist: compare(Object, Object) method not found on nullsLast Comparator.")
+
+    compareMethod.addInstructionsWithLabels(
+        0,
+        """
+            if-eq p1, p2, :equal
+            if-eqz p1, :p1_null
+            if-eqz p2, :p2_null
+            goto :original
+            :p1_null
+            const/4 v0, -0x1
+            return v0
+            :p2_null
+            const/4 v0, 0x1
+            return v0
+            :equal
+            const/4 v0, 0x0
+            return v0
+        """,
+        ExternalLabel("original", compareMethod.getInstruction(0)),
+    )
+}


### PR DESCRIPTION
## Description

Adds a new patch **No date first** for Todoist (`com.todoist` v12190).

### What it does
In grouped views (such as Upcoming date grouping), Todoist uses a `TreeMap` with Kotlin's `nullsLast` comparator (`gz.b`) to sort group sections. Undated tasks (`"No date"` / `"Sans date"`) use a `null` key, which `nullsLast` sorts at the bottom of the list.

This patch prepends `nullsFirst` logic to `compare()` on the `nullsLast` comparator class (`gz.b`), causing `TreeMap` to place undated task sections at the very top of the list while preserving normal chronological date sorting for dated tasks.

### Verification
- Tested locally with `./gradlew :patches:buildAndroid` and verified on-device with Todoist v12190.
- Regenerated `patches-list.json` and updated `README.md`.